### PR TITLE
Remove unsupported USE_SMART_DB feature and simplify codebase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,6 @@ option(USE_RDMA "Use RDMA RSockets networking (default: ON, use TCP when OFF)" O
 option(USE_HWLOC "Use hwloc for hardware topology (default: ON, disable when OFF)" ON)
 option(USE_GPU "Enable GPU support (default: ON, disable when OFF)" ON)
 option(USE_SIMPLE_ARCH "Use simple architecture implementations" OFF)
-option(USE_SMART_DB "Enable smart database features (currently not supported)" OFF)
 option(ARTS_INFO_ENABLED "Enable info-level logging" OFF)
 option(ARTS_DEBUG_ENABLED "Enable debug-level logging" OFF)
 option(USE_PRIORITY_DEQUE "Use priority Chase-Lev deque implementation" OFF)
@@ -283,12 +282,6 @@ endif()
 if(USE_SIMPLE_ARCH)
     add_compile_definitions(USE_SIMPLE_ARCH)
     message(STATUS "Architecture: Simple CAS2 and BIT_TEST_AND_SET enabled - USE_SIMPLE_ARCH defined")
-endif()
-
-# Smart database flags
-if(USE_SMART_DB)
-    add_compile_definitions(USE_SMART_DB)
-    message(STATUS "Smart database: Using smart database - USE_SMART_DB defined")
 endif()
 
 if(ARTS_INFO_ENABLED)

--- a/core/inc/arts/arts.h
+++ b/core/inc/arts/arts.h
@@ -454,7 +454,6 @@ bool artsDbRenameWithGuid(artsGuid_t newGuid, artsGuid_t oldGuid);
 
 artsGuid_t artsDbCopyToNewType(artsGuid_t oldGuid, artsType_t newType);
 
-#ifdef USE_SMART_DB
 // Increment the latch count associated with the persistent event of the DB
 void artsDbIncrementLatch(artsGuid_t guid);
 
@@ -480,7 +479,6 @@ void artsDbAddDependenceWithModeAndDiff(artsGuid_t dbSrc, artsGuid_t edtDest,
 // ARTS_DB_WRITE
 void artsRecordDep(artsGuid_t dbSrc, artsGuid_t edtDest, uint32_t edtSlot,
                    artsType_t acquireMode, bool useTwinDiff);
-#endif
 
 /*Epoch************************************************************************/
 

--- a/core/inc/arts/network/RemoteProtocol.h
+++ b/core/inc/arts/network/RemoteProtocol.h
@@ -52,11 +52,9 @@ enum artsServerMessageType {
   ARTS_REMOTE_PERSISTENT_EVENT_SATISFY_SLOT_MSG,
   ARTS_REMOTE_ADD_DEPENDENCE_MSG,
   ARTS_REMOTE_ADD_DEPENDENCE_TO_PERSISTENT_EVENT_MSG,
-#ifdef USE_SMART_DB
   ARTS_REMOTE_DB_ADD_DEPENDENCE_MSG,
   ARTS_REMOTE_DB_INCREMENT_LATCH_MSG,
   ARTS_REMOTE_DB_DECREMENT_LATCH_MSG,
-#endif
   ARTS_REMOTE_DB_REQUEST_MSG,
   ARTS_REMOTE_DB_SEND_MSG,
   ARTS_REMOTE_INVALIDATE_DB_MSG,
@@ -145,7 +143,6 @@ struct __attribute__((__packed__)) artsRemotePersistentEventSatisfySlotPacket {
   bool lock;
 };
 
-#ifdef USE_SMART_DB
 struct __attribute__((__packed__)) artsRemoteDbAddDependencePacket {
   struct artsRemotePacket header;
   artsGuid_t dbSrc;
@@ -155,7 +152,7 @@ struct __attribute__((__packed__)) artsRemoteDbAddDependencePacket {
   uint8_t useTwinDiff;
   uint8_t reserved[3];
 };
-#endif
+
 struct __attribute__((__packed__)) artsRemoteDbRequestPacket {
   struct artsRemotePacket header;
   artsGuid_t dbGuid;

--- a/core/inc/arts/runtime/RT.h
+++ b/core/inc/arts/runtime/RT.h
@@ -142,9 +142,7 @@ struct artsDb {
   struct artsHeader header;
   uint64_t arts_id;           // Unique identifier from compiler (0 if not set)
   artsGuid_t guid;
-#ifdef USE_SMART_DB
   artsGuid_t eventGuid;
-#endif
   volatile unsigned int copyCount;
   volatile unsigned int reader;
   volatile unsigned int writer;

--- a/core/src/gpu/GpuRuntime.cu
+++ b/core/src/gpu/GpuRuntime.cu
@@ -165,10 +165,10 @@ artsGuid_t internalEdtCreateGpu(artsEdt_t funcPtr, artsGuid_t *guid,
   edt->lib = lib;
 
   // artsIntrospectionEdtCreateBegin();
-  bool created = artsEdtCreateInternal((struct artsEdt *)edt, ARTS_GPU_EDT,
-                                       guid, route, artsThreadInfo.clusterId,
-                                       edtSpace, NULL_GUID, funcPtr, paramc,
-                                       paramv, depc, true, NULL_GUID, hasDepv);
+  bool created = artsEdtCreateInternal(
+      (struct artsEdt *)edt, ARTS_GPU_EDT, guid, route,
+      artsThreadInfo.clusterId, edtSpace, NULL_GUID, funcPtr, paramc, paramv,
+      depc, true, NULL_GUID, hasDepv, 0);
   // artsIntrospectionEdtCreateFinish(created);
   //    ARTSEDTCOUNTERTIMERENDINCREMENT(edtCreateCounter);
   return *guid;

--- a/core/src/gpu/GpuStream.cu
+++ b/core/src/gpu/GpuStream.cu
@@ -50,6 +50,7 @@
 #include "arts/gpu/GpuRouteTable.h"
 #include "arts/gpu/GpuRuntime.cuh"
 #include "arts/gpu/GpuStreamBuffer.h"
+#include "arts/introspection/Metrics.h"
 #include "arts/runtime/Globals.h"
 #include "arts/runtime/compute/EdtFunctions.h"
 #include "arts/system/ArtsPrint.h"

--- a/core/src/runtime/Server.c
+++ b/core/src/runtime/Server.c
@@ -132,7 +132,6 @@ void artsServerProcessPacket(struct artsRemotePacket *packet) {
     artsPersistentEventSatisfy(pack->event, pack->action, pack->lock);
     break;
   }
-#ifdef USE_SMART_DB
   case ARTS_REMOTE_DB_INCREMENT_LATCH_MSG: {
     struct artsRemoteGuidOnlyPacket *pack =
         (struct artsRemoteGuidOnlyPacket *)(packet);
@@ -153,7 +152,6 @@ void artsServerProcessPacket(struct artsRemotePacket *packet) {
                                        pack->useTwinDiff);
     break;
   }
-#endif
   case ARTS_REMOTE_DB_REQUEST_MSG: {
     struct artsRemoteDbRequestPacket *pack =
         (struct artsRemoteDbRequestPacket *)(packet);

--- a/core/src/runtime/network/RemoteFunctions.c
+++ b/core/src/runtime/network/RemoteFunctions.c
@@ -284,9 +284,7 @@ void artsRemoteHandleUpdateDb(void *ptr) {
     } else {
       artsProgressFrontier(db, packet->header.rank);
     }
-#ifdef USE_SMART_DB
     artsDbDecrementLatch(packet->guid);
-#endif
   }
 }
 
@@ -401,9 +399,7 @@ void artsRemoteHandlePartialUpdate(void *ptr) {
   artsRouteTableSetRank(packet->guid, artsGlobalRankId);
   artsProgressFrontier(db, artsGlobalRankId);
 
-#ifdef USE_SMART_DB
   artsDbDecrementLatch(packet->guid);
-#endif
 
   ARTS_DEBUG("Partial update applied successfully for DB[Guid:%lu]",
              packet->guid);
@@ -577,7 +573,6 @@ void artsRemotePersistentEventSatisfySlot(artsGuid_t eventGuid, uint32_t action,
                              sizeof(packet));
 }
 
-#ifdef USE_SMART_DB
 static void sendRemoteDbAddDependencePacket(artsGuid_t dbSrc,
                                             artsGuid_t edtDest,
                                             uint32_t edtSlot,
@@ -626,7 +621,6 @@ void artsRemoteDbDecrementLatch(artsGuid_t db) {
   artsRemoteSendRequestAsync(artsGuidGetRank(db), (char *)&packet,
                              sizeof(packet));
 }
-#endif
 
 void artsDbRequestCallback(struct artsEdt *edt, unsigned int slot,
                            struct artsDb *dbRes) {

--- a/test/README_ARTSID_TEST.md
+++ b/test/README_ARTSID_TEST.md
@@ -301,7 +301,6 @@ artsIdEdtMetrics=THREAD
 **Cause**: Possible EDT dependency issue
 
 **Solution**: Check ARTS configuration:
-- Ensure `USE_SMART_DB` is defined if using smart DBs
 - Verify epoch handling is correct
 - Check MPI configuration for multi-node runs
 


### PR DESCRIPTION
This pull request removes all code and configuration related to the `USE_SMART_DB` (smart database) feature, which was previously disabled by default and marked as not supported. The changes simplify the codebase by eliminating conditional compilation blocks, related functions, and configuration options for smart database features.

Key changes include:

**Build and Configuration Cleanup:**
- Removed the `USE_SMART_DB` CMake option and all related build logic from `CMakeLists.txt`. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL91) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL288-L293)

**Codebase Simplification (Smart DB Feature Removal):**
- Eliminated all `#ifdef USE_SMART_DB` conditional blocks and related code from headers and source files, including function definitions, struct members, and message types related to smart database features in files such as `arts.h`, `RemoteProtocol.h`, `RT.h`, and multiple runtime source files. [[1]](diffhunk://#diff-e6f9bc910502fb323d89d44660c6d73e703c1e13f897a7a6aa119e2a3a4b751dL457) [[2]](diffhunk://#diff-e6f9bc910502fb323d89d44660c6d73e703c1e13f897a7a6aa119e2a3a4b751dL483) [[3]](diffhunk://#diff-d4695b1ab07b585730cec52345a5111fea329e20fbce5d17455c4f9901027fdcL55-L59) [[4]](diffhunk://#diff-d4695b1ab07b585730cec52345a5111fea329e20fbce5d17455c4f9901027fdcL148) [[5]](diffhunk://#diff-d4695b1ab07b585730cec52345a5111fea329e20fbce5d17455c4f9901027fdcL158-R155) [[6]](diffhunk://#diff-3ae413f8c5657b8be4bc79b76bf4a6d4cea5f8d699f96bf188d17d94fa358a01L145-L147) [[7]](diffhunk://#diff-06eed95892a16e8e6767fa4381b61248fdccca29dd6c291926e1c3e77d7eeb1dL135) [[8]](diffhunk://#diff-06eed95892a16e8e6767fa4381b61248fdccca29dd6c291926e1c3e77d7eeb1dL156) [[9]](diffhunk://#diff-9b554ef0afc691bb26b0e2ada01c056d6825e19493473a91f4470ba5f205bd52L126-L128) [[10]](diffhunk://#diff-9b554ef0afc691bb26b0e2ada01c056d6825e19493473a91f4470ba5f205bd52L398) [[11]](diffhunk://#diff-9b554ef0afc691bb26b0e2ada01c056d6825e19493473a91f4470ba5f205bd52L452) [[12]](diffhunk://#diff-9b554ef0afc691bb26b0e2ada01c056d6825e19493473a91f4470ba5f205bd52L775-L788) [[13]](diffhunk://#diff-9b554ef0afc691bb26b0e2ada01c056d6825e19493473a91f4470ba5f205bd52L811-L821) [[14]](diffhunk://#diff-9b554ef0afc691bb26b0e2ada01c056d6825e19493473a91f4470ba5f205bd52L834-L836) [[15]](diffhunk://#diff-51779ed7cf7bf1c3fafc9a256c08b53619da782cfe449909756642952481c03eL287-L289) [[16]](diffhunk://#diff-51779ed7cf7bf1c3fafc9a256c08b53619da782cfe449909756642952481c03eL404-L406) [[17]](diffhunk://#diff-51779ed7cf7bf1c3fafc9a256c08b53619da782cfe449909756642952481c03eL580) [[18]](diffhunk://#diff-51779ed7cf7bf1c3fafc9a256c08b53619da782cfe449909756642952481c03eL629)

**Documentation Update:**
- Removed references to `USE_SMART_DB` from documentation, specifically from `test/README_ARTSID_TEST.md`.

These changes collectively remove all traces of the unsupported smart database feature, resulting in a cleaner and more maintainable codebase.