### PR TITLE
Refactor Performance Counters: Add Periodic Mode, Cluster Aggregation, and Time Sync

### DIFF
--- a/core/inc/arts/introspection/CMakeLists.txt
+++ b/core/inc/arts/introspection/CMakeLists.txt
@@ -118,7 +118,7 @@ foreach(LINE ${COUNTER_CONFIG_LINES})
             if(CAPTURE_MODE STREQUAL "ONCE")
                 set(CAPTURE_MODE_${KEY} 1) # artsCaptureModeOnce
             elseif(CAPTURE_MODE STREQUAL "PERIODIC")
-                set(CAPTURE_MODE_${KEY} 2) # artsCaptureModesPeriodic
+                set(CAPTURE_MODE_${KEY} 2) # artsCaptureModePeriodic
             endif()
 
             # Set capture level

--- a/core/inc/arts/introspection/CMakeLists.txt
+++ b/core/inc/arts/introspection/CMakeLists.txt
@@ -86,7 +86,7 @@ set(ENABLED_COUNT 0)
 set(DISABLED_COUNT 0)
 
 # Counter capture mode values: 0=OFF, 1=ONCE, 2=PERIODIC
-# Counter capture level values: 0=THREAD, 1=NODE
+# Counter capture level values: 0=THREAD, 1=NODE, 2=CLUSTER
 # Format: COUNTER=captureMode[,captureLevel]
 # Default captureLevel is NODE (1)
 foreach(LINE ${COUNTER_CONFIG_LINES})

--- a/core/inc/arts/introspection/CMakeLists.txt
+++ b/core/inc/arts/introspection/CMakeLists.txt
@@ -185,7 +185,7 @@ foreach(COUNTER ${COUNTER_TYPES})
 endforeach()
 
 # Generate capture level flags for counters
-file(APPEND ${GENERATED_HEADER} "\n/* Counter Capture Level Flags (0=THREAD, 1=NODE) */\n")
+file(APPEND ${GENERATED_HEADER} "\n/* Counter Capture Level Flags (0=THREAD, 1=NODE, 2=CLUSTER) */\n")
 foreach(COUNTER ${COUNTER_TYPES})
     if(NOT DEFINED CAPTURE_LEVEL_${COUNTER})
         set(CAPTURE_LEVEL_${COUNTER} 1) # Default to NODE
@@ -253,7 +253,7 @@ file(APPEND ${GENERATED_HEADER} "};\n\n")
 
 # Generate counter capture level array
 file(APPEND ${GENERATED_HEADER} "
-/* Counter capture level array (0=THREAD, 1=NODE) */
+/* Counter capture level array (0=THREAD, 1=NODE, 2=CLUSTER) */
 static const unsigned int artsCaptureLevelArray[] = {
 ")
 

--- a/core/inc/arts/introspection/CMakeLists.txt
+++ b/core/inc/arts/introspection/CMakeLists.txt
@@ -64,7 +64,7 @@ set(COUNTER_TYPES)
 foreach(MATCH ${MATCHES})
     # Extract just the identifier name (first capture group)
     string(REGEX MATCH "([a-zA-Z_][a-zA-Z0-9_]*)" COUNTER_NAME "${MATCH}")
-    
+
     # Skip NUM_COUNTER_TYPES
     if(COUNTER_NAME AND NOT COUNTER_NAME STREQUAL "NUM_COUNTER_TYPES")
         list(APPEND COUNTER_TYPES "${COUNTER_NAME}")
@@ -94,11 +94,11 @@ foreach(LINE ${COUNTER_CONFIG_LINES})
         continue()
     endif()
     # Match: COUNTER=MODE or COUNTER=MODE,LEVEL
-    if(LINE MATCHES "^([A-Za-z0-9_]+)[ \\t]*=[ \\t]*(OFF|ONCE|PERIODIC)(,[ \\t]*(THREAD|NODE))?")
+    if(LINE MATCHES "^([A-Za-z0-9_]+)[ \\t]*=[ \\t]*(OFF|ONCE|PERIODIC)(,[ \\t]*(THREAD|NODE|CLUSTER))?")
         set(KEY ${CMAKE_MATCH_1})
         set(CAPTURE_MODE ${CMAKE_MATCH_2})
         set(CAPTURE_LEVEL ${CMAKE_MATCH_4})
-        
+
         # Default captureLevel to NODE if not specified
         if(NOT CAPTURE_LEVEL)
             set(CAPTURE_LEVEL "NODE")
@@ -107,25 +107,27 @@ foreach(LINE ${COUNTER_CONFIG_LINES})
         # Set CMake variables for this counter
         if(CAPTURE_MODE STREQUAL "OFF")
             set(ENABLE_${KEY} 0)
-            set(CAPTURE_MODE_${KEY} 0)  # artsCaptureModeOff
+            set(CAPTURE_MODE_${KEY} 0) # artsCaptureModeOff
             set(CAPTURE_LEVEL_${KEY} 1) # default to NODE
             math(EXPR DISABLED_COUNT "${DISABLED_COUNT} + 1")
         else()
             set(ENABLE_${KEY} 1)
             math(EXPR ENABLED_COUNT "${ENABLED_COUNT} + 1")
-            
+
             # Set capture mode
             if(CAPTURE_MODE STREQUAL "ONCE")
-                set(CAPTURE_MODE_${KEY} 1)  # artsCaptureModeOnce
+                set(CAPTURE_MODE_${KEY} 1) # artsCaptureModeOnce
             elseif(CAPTURE_MODE STREQUAL "PERIODIC")
-                set(CAPTURE_MODE_${KEY} 2)  # artsCaptureModesPeriodic
+                set(CAPTURE_MODE_${KEY} 2) # artsCaptureModesPeriodic
             endif()
-            
+
             # Set capture level
             if(CAPTURE_LEVEL STREQUAL "THREAD")
-                set(CAPTURE_LEVEL_${KEY} 0)  # artsCaptureLevelThread
+                set(CAPTURE_LEVEL_${KEY} 0) # artsCaptureLevelThread
             elseif(CAPTURE_LEVEL STREQUAL "NODE")
-                set(CAPTURE_LEVEL_${KEY} 1)  # artsCaptureLevelNode
+                set(CAPTURE_LEVEL_${KEY} 1) # artsCaptureLevelNode
+            elseif(CAPTURE_LEVEL STREQUAL "CLUSTER")
+                set(CAPTURE_LEVEL_${KEY} 2) # artsCaptureLevelCluster
             endif()
         endif()
     endif()
@@ -186,7 +188,7 @@ endforeach()
 file(APPEND ${GENERATED_HEADER} "\n/* Counter Capture Level Flags (0=THREAD, 1=NODE) */\n")
 foreach(COUNTER ${COUNTER_TYPES})
     if(NOT DEFINED CAPTURE_LEVEL_${COUNTER})
-        set(CAPTURE_LEVEL_${COUNTER} 1)  # Default to NODE
+        set(CAPTURE_LEVEL_${COUNTER} 1) # Default to NODE
     endif()
     file(APPEND ${GENERATED_HEADER} "#define CAPTURE_LEVEL_${COUNTER} ${CAPTURE_LEVEL_${COUNTER}}\n")
 endforeach()
@@ -257,7 +259,7 @@ static const unsigned int artsCaptureLevelArray[] = {
 
 foreach(COUNTER ${COUNTER_TYPES})
     if(NOT DEFINED CAPTURE_LEVEL_${COUNTER})
-        set(CAPTURE_LEVEL_${COUNTER} 1)  # Default to NODE
+        set(CAPTURE_LEVEL_${COUNTER} 1) # Default to NODE
     endif()
     file(APPEND ${GENERATED_HEADER} "    ${CAPTURE_LEVEL_${COUNTER}},  /* ${COUNTER} */\n")
 endforeach()

--- a/core/inc/arts/introspection/CMakeLists.txt
+++ b/core/inc/arts/introspection/CMakeLists.txt
@@ -85,32 +85,48 @@ file(STRINGS "${COUNTER_CONFIG_PATH}" COUNTER_CONFIG_LINES)
 set(ENABLED_COUNT 0)
 set(DISABLED_COUNT 0)
 
-# Counter mode values: 0=OFF, 1=ONCE, 2=THREAD, 3=NODE
+# Counter capture mode values: 0=OFF, 1=ONCE, 2=PERIODIC
+# Counter capture level values: 0=THREAD, 1=NODE
+# Format: COUNTER=captureMode[,captureLevel]
+# Default captureLevel is NODE (1)
 foreach(LINE ${COUNTER_CONFIG_LINES})
     if(LINE MATCHES "^[ \\t]*#" OR LINE MATCHES "^[ \\t]*$")
         continue()
     endif()
-    if(LINE MATCHES "^([A-Za-z0-9_]+)[ \\t]*=[ \\t]*(OFF|ONCE|THREAD|NODE)")
+    # Match: COUNTER=MODE or COUNTER=MODE,LEVEL
+    if(LINE MATCHES "^([A-Za-z0-9_]+)[ \\t]*=[ \\t]*(OFF|ONCE|PERIODIC)(,[ \\t]*(THREAD|NODE))?")
         set(KEY ${CMAKE_MATCH_1})
-        set(VALUE ${CMAKE_MATCH_2})
+        set(CAPTURE_MODE ${CMAKE_MATCH_2})
+        set(CAPTURE_LEVEL ${CMAKE_MATCH_4})
+        
+        # Default captureLevel to NODE if not specified
+        if(NOT CAPTURE_LEVEL)
+            set(CAPTURE_LEVEL "NODE")
+        endif()
 
-        # Set CMake variable for this counter mode
-        if(VALUE STREQUAL "OFF")
+        # Set CMake variables for this counter
+        if(CAPTURE_MODE STREQUAL "OFF")
             set(ENABLE_${KEY} 0)
-            set(MODE_${KEY} 0)
+            set(CAPTURE_MODE_${KEY} 0)  # artsCaptureModeOff
+            set(CAPTURE_LEVEL_${KEY} 1) # default to NODE
             math(EXPR DISABLED_COUNT "${DISABLED_COUNT} + 1")
-        elseif(VALUE STREQUAL "ONCE")
+        else()
             set(ENABLE_${KEY} 1)
-            set(MODE_${KEY} 1)
             math(EXPR ENABLED_COUNT "${ENABLED_COUNT} + 1")
-        elseif(VALUE STREQUAL "THREAD")
-            set(ENABLE_${KEY} 1)
-            set(MODE_${KEY} 2)
-            math(EXPR ENABLED_COUNT "${ENABLED_COUNT} + 1")
-        elseif(VALUE STREQUAL "NODE")
-            set(ENABLE_${KEY} 1)
-            set(MODE_${KEY} 3)
-            math(EXPR ENABLED_COUNT "${ENABLED_COUNT} + 1")
+            
+            # Set capture mode
+            if(CAPTURE_MODE STREQUAL "ONCE")
+                set(CAPTURE_MODE_${KEY} 1)  # artsCaptureModeOnce
+            elseif(CAPTURE_MODE STREQUAL "PERIODIC")
+                set(CAPTURE_MODE_${KEY} 2)  # artsCaptureModesPeriodic
+            endif()
+            
+            # Set capture level
+            if(CAPTURE_LEVEL STREQUAL "THREAD")
+                set(CAPTURE_LEVEL_${KEY} 0)  # artsCaptureLevelThread
+            elseif(CAPTURE_LEVEL STREQUAL "NODE")
+                set(CAPTURE_LEVEL_${KEY} 1)  # artsCaptureLevelNode
+            endif()
         endif()
     endif()
 endforeach()
@@ -157,13 +173,22 @@ foreach(COUNTER ${COUNTER_TYPES})
     file(APPEND ${GENERATED_HEADER} "#define ENABLE_${COUNTER} ${ENABLE_${COUNTER}}\n")
 endforeach()
 
-# Generate mode flags for counters
-file(APPEND ${GENERATED_HEADER} "\n/* Counter Mode Flags (0=OFF, 1=ONCE, 2=THREAD, 3=NODE) */\n")
+# Generate capture mode flags for counters
+file(APPEND ${GENERATED_HEADER} "\n/* Counter Capture Mode Flags (0=OFF, 1=ONCE, 2=PERIODIC) */\n")
 foreach(COUNTER ${COUNTER_TYPES})
-    if(NOT DEFINED MODE_${COUNTER})
-        set(MODE_${COUNTER} 0)
+    if(NOT DEFINED CAPTURE_MODE_${COUNTER})
+        set(CAPTURE_MODE_${COUNTER} 0)
     endif()
-    file(APPEND ${GENERATED_HEADER} "#define MODE_${COUNTER} ${MODE_${COUNTER}}\n")
+    file(APPEND ${GENERATED_HEADER} "#define CAPTURE_MODE_${COUNTER} ${CAPTURE_MODE_${COUNTER}}\n")
+endforeach()
+
+# Generate capture level flags for counters
+file(APPEND ${GENERATED_HEADER} "\n/* Counter Capture Level Flags (0=THREAD, 1=NODE) */\n")
+foreach(COUNTER ${COUNTER_TYPES})
+    if(NOT DEFINED CAPTURE_LEVEL_${COUNTER})
+        set(CAPTURE_LEVEL_${COUNTER} 1)  # Default to NODE
+    endif()
+    file(APPEND ${GENERATED_HEADER} "#define CAPTURE_LEVEL_${COUNTER} ${CAPTURE_LEVEL_${COUNTER}}\n")
 endforeach()
 
 # Generate counter macros automatically
@@ -209,17 +234,32 @@ file(APPEND ${GENERATED_HEADER} "
 
 ")
 
-# Generate counter mode array
+# Generate counter capture mode array
 file(APPEND ${GENERATED_HEADER} "
-/* Counter mode array (0=OFF, 1=ONCE, 2=THREAD, 3=NODE) */
-static const unsigned int artsCounterMode[] = {
+/* Counter capture mode array (0=OFF, 1=ONCE, 2=PERIODIC) */
+static const unsigned int artsCaptureModeArray[] = {
 ")
 
 foreach(COUNTER ${COUNTER_TYPES})
-    if(NOT DEFINED MODE_${COUNTER})
-        set(MODE_${COUNTER} 0)
+    if(NOT DEFINED CAPTURE_MODE_${COUNTER})
+        set(CAPTURE_MODE_${COUNTER} 0)
     endif()
-    file(APPEND ${GENERATED_HEADER} "    ${MODE_${COUNTER}},  /* ${COUNTER} */\n")
+    file(APPEND ${GENERATED_HEADER} "    ${CAPTURE_MODE_${COUNTER}},  /* ${COUNTER} */\n")
+endforeach()
+
+file(APPEND ${GENERATED_HEADER} "};\n\n")
+
+# Generate counter capture level array
+file(APPEND ${GENERATED_HEADER} "
+/* Counter capture level array (0=THREAD, 1=NODE) */
+static const unsigned int artsCaptureLevelArray[] = {
+")
+
+foreach(COUNTER ${COUNTER_TYPES})
+    if(NOT DEFINED CAPTURE_LEVEL_${COUNTER})
+        set(CAPTURE_LEVEL_${COUNTER} 1)  # Default to NODE
+    endif()
+    file(APPEND ${GENERATED_HEADER} "    ${CAPTURE_LEVEL_${COUNTER}},  /* ${COUNTER} */\n")
 endforeach()
 
 file(APPEND ${GENERATED_HEADER} "};\n\n")

--- a/core/inc/arts/introspection/CMakeLists.txt
+++ b/core/inc/arts/introspection/CMakeLists.txt
@@ -41,7 +41,7 @@
 # Define All Counters - Parse from Counter.h
 # =============================================================================
 
-# Read Counter.h and extract counter types from artsCounterType enum
+# Read Counter.h and extract counter types from ARTS_COUNTER_LIST macro
 set(COUNTER_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/Counter.h")
 if(NOT EXISTS "${COUNTER_HEADER}")
     message(FATAL_ERROR "Counter.h not found at: ${COUNTER_HEADER}")
@@ -49,24 +49,17 @@ endif()
 
 file(READ "${COUNTER_HEADER}" COUNTER_HEADER_CONTENT)
 
-# Extract the enum artsCounterType block
-string(REGEX MATCH "typedef enum artsCounterType[^}]*}" ENUM_BLOCK "${COUNTER_HEADER_CONTENT}")
-
-if(NOT ENUM_BLOCK)
-    message(FATAL_ERROR "Could not find artsCounterType enum in Counter.h")
-endif()
-
-# Extract counter names from the enum - match identifiers at start of line or after whitespace
-# This regex matches: optional whitespace, identifier, optional "= digit", followed by comma or newline
-string(REGEX MATCHALL "[ \t\n\r]+([a-zA-Z_][a-zA-Z0-9_]*)[ \t]*(=[ \t]*[0-9]+)?[ \t]*," MATCHES "${ENUM_BLOCK}")
+# Extract counter names from X(counterName) patterns in ARTS_COUNTER_LIST
+# This matches all X(identifier) patterns
+string(REGEX MATCHALL "X\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)" MATCHES "${COUNTER_HEADER_CONTENT}")
 
 set(COUNTER_TYPES)
 foreach(MATCH ${MATCHES})
-    # Extract just the identifier name (first capture group)
-    string(REGEX MATCH "([a-zA-Z_][a-zA-Z0-9_]*)" COUNTER_NAME "${MATCH}")
+    # Extract just the identifier name from X(name)
+    string(REGEX REPLACE "X\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)" "\\1" COUNTER_NAME "${MATCH}")
 
-    # Skip NUM_COUNTER_TYPES
-    if(COUNTER_NAME AND NOT COUNTER_NAME STREQUAL "NUM_COUNTER_TYPES")
+    # Skip 'name' and 'counterName' which appear in comments/definitions
+    if(COUNTER_NAME AND NOT COUNTER_NAME STREQUAL "name" AND NOT COUNTER_NAME STREQUAL "counterName")
         list(APPEND COUNTER_TYPES "${COUNTER_NAME}")
     endif()
 endforeach()
@@ -85,49 +78,68 @@ file(STRINGS "${COUNTER_CONFIG_PATH}" COUNTER_CONFIG_LINES)
 set(ENABLED_COUNT 0)
 set(DISABLED_COUNT 0)
 
-# Counter capture mode values: 0=OFF, 1=ONCE, 2=PERIODIC
-# Counter capture level values: 0=THREAD, 1=NODE, 2=CLUSTER
-# Format: COUNTER=captureMode[,captureLevel]
-# Default captureLevel is NODE (1)
+# Counter mode values: 0=OFF, 1=ONCE, 2=PERIODIC
+# Counter level values: 0=THREAD, 1=NODE, 2=CLUSTER
+# Counter reduce method values: 0=SUM, 1=MAX, 2=MIN, 3=MASTER
+# Format: COUNTER=counterMode[,counterLevel[,reduceMethod]]
+# Default counterLevel is NODE (1), default reduceMethod is SUM (0)
 foreach(LINE ${COUNTER_CONFIG_LINES})
     if(LINE MATCHES "^[ \\t]*#" OR LINE MATCHES "^[ \\t]*$")
         continue()
     endif()
-    # Match: COUNTER=MODE or COUNTER=MODE,LEVEL
-    if(LINE MATCHES "^([A-Za-z0-9_]+)[ \\t]*=[ \\t]*(OFF|ONCE|PERIODIC)(,[ \\t]*(THREAD|NODE|CLUSTER))?")
+    # Match: COUNTER=MODE or COUNTER=MODE,LEVEL or COUNTER=MODE,LEVEL,REDUCE
+    if(LINE MATCHES "^([A-Za-z0-9_]+)[ \\t]*=[ \\t]*(OFF|ONCE|PERIODIC)(,[ \\t]*(THREAD|NODE|CLUSTER))?(,[ \\t]*(SUM|MAX|MIN|MASTER))?")
         set(KEY ${CMAKE_MATCH_1})
-        set(CAPTURE_MODE ${CMAKE_MATCH_2})
-        set(CAPTURE_LEVEL ${CMAKE_MATCH_4})
+        set(COUNTER_MODE ${CMAKE_MATCH_2})
+        set(COUNTER_LEVEL ${CMAKE_MATCH_4})
+        set(REDUCE_METHOD ${CMAKE_MATCH_6})
 
-        # Default captureLevel to NODE if not specified
-        if(NOT CAPTURE_LEVEL)
-            set(CAPTURE_LEVEL "NODE")
+        # Default counterLevel to NODE if not specified
+        if(NOT COUNTER_LEVEL)
+            set(COUNTER_LEVEL "NODE")
+        endif()
+
+        # Default reduceMethod to SUM if not specified
+        if(NOT REDUCE_METHOD)
+            set(REDUCE_METHOD "SUM")
         endif()
 
         # Set CMake variables for this counter
-        if(CAPTURE_MODE STREQUAL "OFF")
+        if(COUNTER_MODE STREQUAL "OFF")
             set(ENABLE_${KEY} 0)
-            set(CAPTURE_MODE_${KEY} 0) # artsCaptureModeOff
-            set(CAPTURE_LEVEL_${KEY} 1) # default to NODE
+            set(COUNTER_MODE_${KEY} 0) # artsCounterModeOff
+            set(COUNTER_LEVEL_${KEY} 1) # default to NODE
+            set(REDUCE_METHOD_${KEY} 0) # default to SUM
             math(EXPR DISABLED_COUNT "${DISABLED_COUNT} + 1")
         else()
             set(ENABLE_${KEY} 1)
             math(EXPR ENABLED_COUNT "${ENABLED_COUNT} + 1")
 
-            # Set capture mode
-            if(CAPTURE_MODE STREQUAL "ONCE")
-                set(CAPTURE_MODE_${KEY} 1) # artsCaptureModeOnce
-            elseif(CAPTURE_MODE STREQUAL "PERIODIC")
-                set(CAPTURE_MODE_${KEY} 2) # artsCaptureModePeriodic
+            # Set counter mode
+            if(COUNTER_MODE STREQUAL "ONCE")
+                set(COUNTER_MODE_${KEY} 1) # artsCounterModeOnce
+            elseif(COUNTER_MODE STREQUAL "PERIODIC")
+                set(COUNTER_MODE_${KEY} 2) # artsCounterModePeriodic
             endif()
 
-            # Set capture level
-            if(CAPTURE_LEVEL STREQUAL "THREAD")
-                set(CAPTURE_LEVEL_${KEY} 0) # artsCaptureLevelThread
-            elseif(CAPTURE_LEVEL STREQUAL "NODE")
-                set(CAPTURE_LEVEL_${KEY} 1) # artsCaptureLevelNode
-            elseif(CAPTURE_LEVEL STREQUAL "CLUSTER")
-                set(CAPTURE_LEVEL_${KEY} 2) # artsCaptureLevelCluster
+            # Set counter level
+            if(COUNTER_LEVEL STREQUAL "THREAD")
+                set(COUNTER_LEVEL_${KEY} 0) # artsCounterLevelThread
+            elseif(COUNTER_LEVEL STREQUAL "NODE")
+                set(COUNTER_LEVEL_${KEY} 1) # artsCounterLevelNode
+            elseif(COUNTER_LEVEL STREQUAL "CLUSTER")
+                set(COUNTER_LEVEL_${KEY} 2) # artsCounterLevelCluster
+            endif()
+
+            # Set reduce method
+            if(REDUCE_METHOD STREQUAL "SUM")
+                set(REDUCE_METHOD_${KEY} 0) # artsCounterReduceSum
+            elseif(REDUCE_METHOD STREQUAL "MAX")
+                set(REDUCE_METHOD_${KEY} 1) # artsCounterReduceMax
+            elseif(REDUCE_METHOD STREQUAL "MIN")
+                set(REDUCE_METHOD_${KEY} 2) # artsCounterReduceMin
+            elseif(REDUCE_METHOD STREQUAL "MASTER")
+                set(REDUCE_METHOD_${KEY} 3) # artsCounterReduceMaster
             endif()
         endif()
     endif()
@@ -158,8 +170,6 @@ extern \"C\" {
 
 #include <stdbool.h>
 
-#include \"arts/introspection/Counter.h\"
-
 /* ============================================================================
 * Enable/Disable Flags
 * ============================================================================ */
@@ -175,22 +185,31 @@ foreach(COUNTER ${COUNTER_TYPES})
     file(APPEND ${GENERATED_HEADER} "#define ENABLE_${COUNTER} ${ENABLE_${COUNTER}}\n")
 endforeach()
 
-# Generate capture mode flags for counters
-file(APPEND ${GENERATED_HEADER} "\n/* Counter Capture Mode Flags (0=OFF, 1=ONCE, 2=PERIODIC) */\n")
+# Generate counter mode flags for counters
+file(APPEND ${GENERATED_HEADER} "\n/* Counter Mode Flags (0=OFF, 1=ONCE, 2=PERIODIC) */\n")
 foreach(COUNTER ${COUNTER_TYPES})
-    if(NOT DEFINED CAPTURE_MODE_${COUNTER})
-        set(CAPTURE_MODE_${COUNTER} 0)
+    if(NOT DEFINED COUNTER_MODE_${COUNTER})
+        set(COUNTER_MODE_${COUNTER} 0)
     endif()
-    file(APPEND ${GENERATED_HEADER} "#define CAPTURE_MODE_${COUNTER} ${CAPTURE_MODE_${COUNTER}}\n")
+    file(APPEND ${GENERATED_HEADER} "#define COUNTER_MODE_${COUNTER} ${COUNTER_MODE_${COUNTER}}\n")
 endforeach()
 
-# Generate capture level flags for counters
-file(APPEND ${GENERATED_HEADER} "\n/* Counter Capture Level Flags (0=THREAD, 1=NODE, 2=CLUSTER) */\n")
+# Generate counter level flags for counters
+file(APPEND ${GENERATED_HEADER} "\n/* Counter Level Flags (0=THREAD, 1=NODE, 2=CLUSTER) */\n")
 foreach(COUNTER ${COUNTER_TYPES})
-    if(NOT DEFINED CAPTURE_LEVEL_${COUNTER})
-        set(CAPTURE_LEVEL_${COUNTER} 1) # Default to NODE
+    if(NOT DEFINED COUNTER_LEVEL_${COUNTER})
+        set(COUNTER_LEVEL_${COUNTER} 1) # Default to NODE
     endif()
-    file(APPEND ${GENERATED_HEADER} "#define CAPTURE_LEVEL_${COUNTER} ${CAPTURE_LEVEL_${COUNTER}}\n")
+    file(APPEND ${GENERATED_HEADER} "#define COUNTER_LEVEL_${COUNTER} ${COUNTER_LEVEL_${COUNTER}}\n")
+endforeach()
+
+# Generate reduce method flags for counters
+file(APPEND ${GENERATED_HEADER} "\n/* Counter Reduce Method Flags (0=SUM, 1=MAX, 2=MIN, 3=MASTER) */\n")
+foreach(COUNTER ${COUNTER_TYPES})
+    if(NOT DEFINED REDUCE_METHOD_${COUNTER})
+        set(REDUCE_METHOD_${COUNTER} 0) # Default to SUM
+    endif()
+    file(APPEND ${GENERATED_HEADER} "#define REDUCE_METHOD_${COUNTER} ${REDUCE_METHOD_${COUNTER}}\n")
 endforeach()
 
 # Generate counter macros automatically
@@ -213,10 +232,10 @@ foreach(COUNTER ${COUNTER_TYPES})
 
     file(APPEND ${GENERATED_HEADER}
         "#if ENABLE_${COUNTER}
-    #define ${TIMER_START}() artsCounterTimerStart(&artsThreadInfo.artsCounters[${COUNTER_INDEX}])
-    #define ${TIMER_STOP}() artsCounterTimerEnd(&artsThreadInfo.artsCounters[${COUNTER_INDEX}])
-    #define ${INCREMENT}(value) artsCounterIncrementBy(&artsThreadInfo.artsCounters[${COUNTER_INDEX}], value)
-    #define ${DECREMENT}(value) artsCounterDecrementBy(&artsThreadInfo.artsCounters[${COUNTER_INDEX}], value)
+    #define ${TIMER_START}() artsCounterTimerStart(&artsThreadLocalCounters[${COUNTER_INDEX}])
+    #define ${TIMER_STOP}() artsCounterTimerEnd(&artsThreadLocalCounters[${COUNTER_INDEX}])
+    #define ${INCREMENT}(value) artsCounterIncrementBy(&artsThreadLocalCounters[${COUNTER_INDEX}], value)
+    #define ${DECREMENT}(value) artsCounterDecrementBy(&artsThreadLocalCounters[${COUNTER_INDEX}], value)
 #else
     #define ${TIMER_START}() ((void)0)
     #define ${TIMER_STOP}() ((void)0)
@@ -236,36 +255,49 @@ file(APPEND ${GENERATED_HEADER} "
 
 ")
 
-# Generate counter capture mode array
+# Generate counter mode array
 file(APPEND ${GENERATED_HEADER} "
-/* Counter capture mode array (0=OFF, 1=ONCE, 2=PERIODIC) */
-static const unsigned int artsCaptureModeArray[] = {
+/* Counter mode array (0=OFF, 1=ONCE, 2=PERIODIC) */
+static const unsigned int artsCounterModeArray[] = {
 ")
 
 foreach(COUNTER ${COUNTER_TYPES})
-    if(NOT DEFINED CAPTURE_MODE_${COUNTER})
-        set(CAPTURE_MODE_${COUNTER} 0)
+    if(NOT DEFINED COUNTER_MODE_${COUNTER})
+        set(COUNTER_MODE_${COUNTER} 0)
     endif()
-    file(APPEND ${GENERATED_HEADER} "    ${CAPTURE_MODE_${COUNTER}},  /* ${COUNTER} */\n")
+    file(APPEND ${GENERATED_HEADER} "    ${COUNTER_MODE_${COUNTER}},  /* ${COUNTER} */\n")
 endforeach()
 
 file(APPEND ${GENERATED_HEADER} "};\n\n")
 
-# Generate counter capture level array
+# Generate counter level array
 file(APPEND ${GENERATED_HEADER} "
-/* Counter capture level array (0=THREAD, 1=NODE, 2=CLUSTER) */
-static const unsigned int artsCaptureLevelArray[] = {
+/* Counter level array (0=THREAD, 1=NODE, 2=CLUSTER) */
+static const unsigned int artsCounterLevelArray[] = {
 ")
 
 foreach(COUNTER ${COUNTER_TYPES})
-    if(NOT DEFINED CAPTURE_LEVEL_${COUNTER})
-        set(CAPTURE_LEVEL_${COUNTER} 1) # Default to NODE
+    if(NOT DEFINED COUNTER_LEVEL_${COUNTER})
+        set(COUNTER_LEVEL_${COUNTER} 1) # Default to NODE
     endif()
-    file(APPEND ${GENERATED_HEADER} "    ${CAPTURE_LEVEL_${COUNTER}},  /* ${COUNTER} */\n")
+    file(APPEND ${GENERATED_HEADER} "    ${COUNTER_LEVEL_${COUNTER}},  /* ${COUNTER} */\n")
 endforeach()
 
 file(APPEND ${GENERATED_HEADER} "};\n\n")
+# Generate counter reduce method array
+file(APPEND ${GENERATED_HEADER} "
+/* Counter reduce method array (0=SUM, 1=MAX, 2=MIN, 3=MASTER) */
+static const unsigned int artsCounterReduceMethodArray[] = {
+")
 
+foreach(COUNTER ${COUNTER_TYPES})
+    if(NOT DEFINED REDUCE_METHOD_${COUNTER})
+        set(REDUCE_METHOD_${COUNTER} 0) # Default to SUM
+    endif()
+    file(APPEND ${GENERATED_HEADER} "    ${REDUCE_METHOD_${COUNTER}},  /* ${COUNTER} */\n")
+endforeach()
+
+file(APPEND ${GENERATED_HEADER} "};\n\n")
 # Function declarations
 file(APPEND ${GENERATED_HEADER} "
 #ifdef __cplusplus

--- a/core/inc/arts/introspection/Counter.h
+++ b/core/inc/arts/introspection/Counter.h
@@ -116,9 +116,9 @@ typedef enum artsCounterCaptureMode {
 
 // Capture level: determines the aggregation level for output
 typedef enum artsCounterCaptureLevel {
-  artsCaptureLevelThread = 0, // Per-thread output (no reduction)
-  artsCaptureLevelNode = 1,   // Per-node output (reduce across threads)
-  // artsCaptureLevelCluster = 2, // Per-cluster (not implemented)
+  artsCaptureLevelThread = 0,  // Per-thread output (no reduction)
+  artsCaptureLevelNode = 1,    // Per-node output (reduce across threads)
+  artsCaptureLevelCluster = 2, // Cluster output (reduce across all nodes)
 } artsCounterCaptureLevel;
 
 typedef struct {
@@ -168,6 +168,7 @@ void artsCounterTimerEnd(artsCounter *counter);
 void artsCounterWriteThread(const char *outputFolder, unsigned int nodeId,
                             unsigned int threadId);
 void artsCounterWriteNode(const char *outputFolder, unsigned int nodeId);
+void artsCounterWriteCluster(const char *outputFolder);
 
 // arts_id tracking wrapper functions (integrated with counter infrastructure)
 void artsCounterRecordArtsIdEdt(uint64_t arts_id, uint64_t exec_ns,

--- a/core/inc/arts/introspection/Counter.h
+++ b/core/inc/arts/introspection/Counter.h
@@ -94,7 +94,11 @@ typedef enum artsCounterType {
   artsIdDbMetrics,
   artsIdEdtCaptures,
   artsIdDbCaptures,
-  // Per-node timing counters
+  // Per-node timing counters.
+  // These counters measure wall-clock durations on each node:
+  // - initializationTime: time spent in ARTS initialization
+  // - endToEndTime: main workload execution time
+  // - finalizationTime: time spent in ARTS finalization
   initializationTime,
   endToEndTime,
   finalizationTime,
@@ -109,9 +113,9 @@ typedef enum artsCounterReduceType {
 
 // Capture mode: determines when/how often counters are captured
 typedef enum artsCounterCaptureMode {
-  artsCaptureModeOff = 0,       // Counter disabled
-  artsCaptureModeOnce = 1,      // Single value at the end (no periodic capture)
-  artsCaptureModesPeriodic = 2, // Periodic capture during execution
+  artsCaptureModeOff = 0,      // Counter disabled
+  artsCaptureModeOnce = 1,     // Single value at the end (no periodic capture)
+  artsCaptureModePeriodic = 2, // Periodic capture during execution
 } artsCounterCaptureMode;
 
 // Capture level: determines the aggregation level for output

--- a/core/inc/arts/introspection/Counter.h
+++ b/core/inc/arts/introspection/Counter.h
@@ -94,6 +94,10 @@ typedef enum artsCounterType {
   artsIdDbMetrics,
   artsIdEdtCaptures,
   artsIdDbCaptures,
+  // Per-node timing counters
+  initializationTime,
+  endToEndTime,
+  finalizationTime,
   NUM_COUNTER_TYPES,
 } artsCounterType;
 
@@ -103,12 +107,19 @@ typedef enum artsCounterReduceType {
   artsCounterMin,
 } artsCounterReduceType;
 
+// Capture mode: determines when/how often counters are captured
 typedef enum artsCounterCaptureMode {
-  artsCounterModeOff = 0,
-  artsCounterModeOnce = 1,   // Print at the end (single output)
-  artsCounterModeThread = 2, // Capture per thread without reduction
-  artsCounterModeNode = 3,   // Capture and reduce per node
+  artsCaptureModeOff = 0,       // Counter disabled
+  artsCaptureModeOnce = 1,      // Single value at the end (no periodic capture)
+  artsCaptureModesPeriodic = 2, // Periodic capture during execution
 } artsCounterCaptureMode;
+
+// Capture level: determines the aggregation level for output
+typedef enum artsCounterCaptureLevel {
+  artsCaptureLevelThread = 0, // Per-thread output (no reduction)
+  artsCaptureLevelNode = 1,   // Per-node output (reduce across threads)
+  // artsCaptureLevelCluster = 2, // Per-cluster (not implemented)
+} artsCounterCaptureLevel;
 
 typedef struct {
   uint64_t count;
@@ -208,7 +219,10 @@ static const char *const artsCounterNames[] = {"edtCounter",
                                                "artsIdEdtMetrics",
                                                "artsIdDbMetrics",
                                                "artsIdEdtCaptures",
-                                               "artsIdDbCaptures"};
+                                               "artsIdDbCaptures",
+                                               "initializationTime",
+                                               "endToEndTime",
+                                               "finalizationTime"};
 
 static const unsigned int artsCounterReduceTypes[] = {
     artsCounterSum, // edtCounter
@@ -251,7 +265,10 @@ static const unsigned int artsCounterReduceTypes[] = {
     artsCounterSum, // artsIdEdtMetrics
     artsCounterSum, // artsIdDbMetrics
     artsCounterSum, // artsIdEdtCaptures
-    artsCounterSum  // artsIdDbCaptures
+    artsCounterSum, // artsIdDbCaptures
+    artsCounterSum, // initializationTime
+    artsCounterSum, // endToEndTime
+    artsCounterSum  // finalizationTime
 };
 
 #ifdef __cplusplus

--- a/core/inc/arts/introspection/JsonWriter.h
+++ b/core/inc/arts/introspection/JsonWriter.h
@@ -67,6 +67,8 @@ void artsJsonWriterWriteDouble(artsJsonWriter *writer, const char *key,
 void artsJsonWriterWriteString(artsJsonWriter *writer, const char *key,
                                const char *value);
 void artsJsonWriterWriteNull(artsJsonWriter *writer, const char *key);
+void artsJsonWriterWriteRawArray(artsJsonWriter *writer, const char *key,
+                                 const char *rawJson);
 void artsJsonWriterFinish(artsJsonWriter *writer);
 
 #ifdef __cplusplus

--- a/core/inc/arts/network/RemoteProtocol.h
+++ b/core/inc/arts/network/RemoteProtocol.h
@@ -88,12 +88,10 @@ enum artsServerMessageType {
   ARTS_REMOTE_DB_RENAME_MSG,
   ARTS_REMOTE_DB_PARTIAL_UPDATE_MSG,
   ARTS_REMOTE_DB_ADD_DEPENDENCE_WITH_BYTE_OFFSET_MSG,
-  ARTS_REMOTE_TIME_SYNC_REQ_MSG,  // Worker -> Master: request sync
-  ARTS_REMOTE_TIME_SYNC_RESP_MSG, // Master -> Worker: response with master time
-  ARTS_REMOTE_COUNTER_REDUCE_MSG, // Worker -> Master: single counter value
-                                  // (one packet per counter for reduction)
-  ARTS_REMOTE_COUNTER_REDUCE_DONE_MSG, // Worker -> Master: signal all counters
-                                       // sent
+  ARTS_REMOTE_TIME_SYNC_REQ_MSG,  // Worker -> Master: request with T1
+  ARTS_REMOTE_TIME_SYNC_RESP_MSG, // Master -> Worker: response with T1, T2
+  ARTS_REMOTE_COUNTER_REDUCE_MSG, // Worker -> Master: send node-reduced
+                                  // counters
 };
 
 // Header
@@ -302,27 +300,30 @@ struct __attribute__((__packed__)) artsRemotePartialUpdatePacket {
   uint32_t reserved;
 };
 
-// Time synchronization request packet (Worker -> Master)
-// Worker sends this with T1 (worker's send time) to initiate sync
+// Time synchronization packets for RTT-based clock sync
+// Worker sends request with its send time T1
 struct __attribute__((__packed__)) artsRemoteTimeSyncReqPacket {
   struct artsRemotePacket header;
   uint64_t workerSendTime; // T1: worker's local time when sending request
 };
 
-// Time synchronization response packet (Master -> Worker)
-// Master responds with its timestamp so worker can calculate offset
+// Master responds with T1 (echoed) and T2 (master's receive time)
 struct __attribute__((__packed__)) artsRemoteTimeSyncRespPacket {
   struct artsRemotePacket header;
-  uint64_t workerSendTime; // T1: echoed back from request
-  uint64_t masterRecvTime; // T2: master's local time when it received request
+  uint64_t workerSendTime; // T1: echoed back
+  uint64_t masterRecvTime; // T2: master's local time when receiving request
 };
 
-// Counter reduction packet (Worker -> Master for CLUSTER level counters)
-// Each worker sends its reduced counter values to master for final aggregation
+// Counter reduce packet: worker sends node-reduced counter values to master
+// For PERIODIC mode, captures follow the fixed-size header as variable-length
+// data
 struct __attribute__((__packed__)) artsRemoteCounterReducePacket {
   struct artsRemotePacket header;
-  unsigned int counterIndex; // Which counter type
-  uint64_t value;            // The reduced value from this node
+  unsigned int nodeId;       // Source node ID
+  unsigned int counterIndex; // Which counter this is for
+  uint64_t value;            // For ONCE mode: the reduced value
+  uint64_t captureCount;     // For PERIODIC mode: number of epoch-value pairs
+  // Variable length: captureCount * (epoch, value) pairs follow
 };
 
 void outInit(unsigned int size);

--- a/core/inc/arts/network/RemoteProtocol.h
+++ b/core/inc/arts/network/RemoteProtocol.h
@@ -90,8 +90,8 @@ enum artsServerMessageType {
   ARTS_REMOTE_DB_ADD_DEPENDENCE_WITH_BYTE_OFFSET_MSG,
   ARTS_REMOTE_TIME_SYNC_REQ_MSG,  // Worker -> Master: request sync
   ARTS_REMOTE_TIME_SYNC_RESP_MSG, // Master -> Worker: response with master time
-  ARTS_REMOTE_COUNTER_REDUCE_MSG, // Worker -> Master: send counter values for
-                                  // cluster reduction
+  ARTS_REMOTE_COUNTER_REDUCE_MSG, // Worker -> Master: single counter value
+                                  // (one packet per counter for reduction)
   ARTS_REMOTE_COUNTER_REDUCE_DONE_MSG, // Worker -> Master: signal all counters
                                        // sent
 };

--- a/core/inc/arts/runtime/Globals.h
+++ b/core/inc/arts/runtime/Globals.h
@@ -107,11 +107,11 @@ struct artsRuntimeShared {
   uint64_t **keys;
   uint64_t *globalGuidThreadId;
   const char *counterFolder;
-  unsigned int counterStartPoint;
-  artsCounterCaptures *counterCaptures;
+  artsCounter **liveCounters;           // [threadId] -> pointer to thread's __thread counters
+  artsCounter **savedCounters;          // [threadId][counterIndex] - final counter values
+  artsArrayList ***captureArrays;       // [threadId][counterIndex] - capture history (PERIODIC)
   uint64_t counterCaptureInterval;
-  artsCounterReduces counterReduces;
-  // arts_id tracking now integrated in counterCaptures and counterReduces
+  // arts_id reduced metrics computed at output time (not stored during runtime)
 } __attribute__((aligned(64)));
 
 struct artsRuntimePrivate {
@@ -136,9 +136,8 @@ struct artsRuntimePrivate {
   int edtFree;
   int localCounting;
   unsigned int shadLock;
-  artsCounter *artsCounters;
   unsigned short drand_buf[3];
-  // arts_id tracking now accessed via counterCaptures[threadId]
+  // Thread's counter storage accessed via artsThreadLocalCounterCaptures
 };
 
 extern struct artsRuntimeShared artsNodeInfo;

--- a/core/inc/arts/runtime/network/RemoteFunctions.h
+++ b/core/inc/arts/runtime/network/RemoteFunctions.h
@@ -176,22 +176,18 @@ void artsRemoteHandleSignalContext(void *pack);
 void artsRemoteDbRename(artsGuid_t newGuid, artsGuid_t oldGuid);
 void artsRemoteHandleDbRename(void *pack);
 
-// Time synchronization for counter capture alignment (RTT-based)
-// Worker initiates sync by sending request to master
-void artsRemoteTimeSyncReqSend(unsigned int masterRank);
-void artsRemoteHandleTimeSyncReq(void *pack);
-// Master responds with its timestamp
-void artsRemoteTimeSyncRespSend(unsigned int workerRank,
-                                uint64_t workerSendTime,
-                                uint64_t masterRecvTime);
-void artsRemoteHandleTimeSyncResp(void *pack);
+// RTT-based time synchronization for precise epoch alignment
+// Worker initiates sync request, master responds, worker calculates offset
+void artsRemoteTimeSyncRequest(void);          // Worker sends request to master
+void artsRemoteHandleTimeSyncReq(void *pack);  // Master handles request
+void artsRemoteHandleTimeSyncResp(void *pack); // Worker handles response
 
-// Counter reduction for CLUSTER level counters
-void artsRemoteCounterReduceSend(unsigned int masterRank,
-                                 unsigned int counterIndex, uint64_t value);
+// Counter cluster reduction via active messaging
+// Worker sends node-reduced counters to master
+void artsRemoteCounterReduceSend(unsigned int counterIndex, uint64_t value,
+                                 uint64_t *epochs, uint64_t *values,
+                                 uint64_t captureCount);
 void artsRemoteHandleCounterReduce(void *pack);
-void artsRemoteCounterReduceDoneSend(unsigned int masterRank);
-void artsRemoteHandleCounterReduceDone(void);
 
 #ifdef __cplusplus
 }

--- a/core/inc/arts/runtime/network/RemoteFunctions.h
+++ b/core/inc/arts/runtime/network/RemoteFunctions.h
@@ -66,7 +66,6 @@ void artsRemoteHandleDbDestroy(void *ptr);
 void artsRemoteUpdateDb(artsGuid_t guid, bool sendDb);
 void artsRemoteHandleUpdateDb(void *ptr);
 
-
 struct artsDiffList;
 void artsRemotePartialUpdateDb(artsGuid_t guid, struct artsDiffList *diffs,
                                void *working);
@@ -176,6 +175,23 @@ void artsRemoteSignalContext(unsigned int rank, uint64_t ticket);
 void artsRemoteHandleSignalContext(void *pack);
 void artsRemoteDbRename(artsGuid_t newGuid, artsGuid_t oldGuid);
 void artsRemoteHandleDbRename(void *pack);
+
+// Time synchronization for counter capture alignment (RTT-based)
+// Worker initiates sync by sending request to master
+void artsRemoteTimeSyncReqSend(unsigned int masterRank);
+void artsRemoteHandleTimeSyncReq(void *pack);
+// Master responds with its timestamp
+void artsRemoteTimeSyncRespSend(unsigned int workerRank,
+                                uint64_t workerSendTime,
+                                uint64_t masterRecvTime);
+void artsRemoteHandleTimeSyncResp(void *pack);
+
+// Counter reduction for CLUSTER level counters
+void artsRemoteCounterReduceSend(unsigned int masterRank,
+                                 unsigned int counterIndex, uint64_t value);
+void artsRemoteHandleCounterReduce(void *pack);
+void artsRemoteCounterReduceDoneSend(unsigned int masterRank);
+void artsRemoteHandleCounterReduceDone(void);
 
 #ifdef __cplusplus
 }

--- a/core/inc/arts/system/Config.h
+++ b/core/inc/arts/system/Config.h
@@ -75,7 +75,6 @@ struct artsConfig {
   unsigned int routeTableEntries;
   unsigned int dequeSize;
   char *counterFolder;
-  unsigned int counterStartPoint;
   unsigned int counterCaptureInterval;
   unsigned int printNodeStats;
   unsigned int scheduler;

--- a/core/src/introspection/Counter.c
+++ b/core/src/introspection/Counter.c
@@ -39,6 +39,7 @@
 #include "arts/introspection/Counter.h"
 
 #include <pthread.h>
+#include <string.h>
 #include <strings.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -53,9 +54,28 @@
 
 // Arrays are defined as static const in Preamble.h (included via arts.h)
 
-static uint64_t countersOn = 0;
+// Thread-local counter storage - simple array of counters.
+// Each thread updates these directly during execution.
+// No captures here - capture thread handles periodic snapshots separately.
+__thread artsCounter artsThreadLocalCounters[NUM_COUNTER_TYPES];
+
+// arts_id tracking stored separately per-thread (compile-time conditional)
+#if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
+__thread artsIdHashTable artsThreadLocalArtsIdMetrics;
+#endif
+#if ENABLE_artsIdEdtCaptures
+__thread artsArrayList *artsThreadLocalEdtCaptureList = NULL;
+#endif
+#if ENABLE_artsIdDbCaptures
+__thread artsArrayList *artsThreadLocalDbCaptureList = NULL;
+#endif
+
+// Capture thread state - only used for periodic counter capture
 static pthread_t captureThread;
 static volatile bool captureThreadRunning = false;
+
+// First capture epoch - used to normalize all epochs to start from 0
+static uint64_t firstCaptureEpoch = 0;
 
 // Time synchronization variables (exported for RemoteFunctions.c)
 // timeOffset = workerTime - masterTime (positive if worker is ahead)
@@ -63,16 +83,21 @@ static volatile bool captureThreadRunning = false;
 volatile int64_t artsCounterTimeOffset = 0;
 volatile bool artsCounterTimeSyncReceived = false;
 
-// Cluster counter reduction storage (exported for RemoteFunctions.c)
-// Only used on master node (rank 0) to aggregate values from all nodes
-uint64_t *artsClusterCounters = NULL;
-volatile unsigned int artsClusterNodesReceived = 0;
+// Cluster reduction state (exported for RemoteFunctions.c)
+// Master allocates these arrays before workers send their data
+volatile unsigned int artsCounterReduceReceived = 0;
+uint64_t **artsClusterCounterValues = NULL; // [counterIndex][nodeId]
+uint64_t ***artsClusterCaptureEpochs =
+    NULL; // [counterIndex][nodeId][captureIdx]
+uint64_t ***artsClusterCaptureValues =
+    NULL; // [counterIndex][nodeId][captureIdx]
+uint64_t **artsClusterCaptureCounts = NULL; // [counterIndex][nodeId]
 
 // Get synchronized timestamp (adjusted to master node's clock)
+// Call this function only after time synchronization is complete
+// artsCounterTimeSyncReceived == true
 static inline uint64_t artsGetSyncedTimeStamp(void) {
-  // Use acquire semantics to ensure we see the offset written by sync response
-  int64_t offset = __atomic_load_n(&artsCounterTimeOffset, __ATOMIC_ACQUIRE);
-  return (uint64_t)((int64_t)artsGetTimeStamp() - offset);
+  return (uint64_t)((int64_t)artsGetTimeStamp() - artsCounterTimeOffset);
 }
 
 static uint64_t artsCounterCaptureCounter(artsCounter *counter) {
@@ -90,8 +115,7 @@ static uint64_t artsCounterCaptureCounter(artsCounter *counter) {
 }
 
 static void *artsCounterCaptureThread(void *args) {
-  // We must set artsCounters to prevent invalid memory access
-  artsThreadInfo.artsCounters = (artsCounter *)args;
+  (void)args; // Unused - capture thread doesn't need its own counters
 
   // Validate counterCaptureInterval to prevent division by zero
   if (artsNodeInfo.counterCaptureInterval == 0) {
@@ -124,815 +148,892 @@ static void *artsCounterCaptureThread(void *args) {
   }
   uint64_t nextCaptureTime = (captureEpoch + 1) * intervalNs;
 
+  // Record the first capture epoch for normalization (epochs will start from 0)
+  firstCaptureEpoch = captureEpoch + 1;
+
   while (captureThreadRunning) {
-    if (countersOn) {
-      syncedTime = artsGetSyncedTimeStamp();
-      // Calculate sleep time until next aligned capture (in synced time)
-      int64_t sleepNs = (int64_t)(nextCaptureTime - syncedTime);
+    syncedTime = artsGetSyncedTimeStamp();
+    // Calculate sleep time until next aligned capture (in synced time)
+    int64_t sleepNs = (int64_t)(nextCaptureTime - syncedTime);
 
-      if (sleepNs > 0) {
-        ARTS_INFO("Debug: nextCaptureTime=%lf ms, syncedTime=%lf ms, "
-                  "sleepTime=%lf ms, offset=%ld ns",
-                  (double)nextCaptureTime / 1000000.0,
-                  (double)syncedTime / 1000000.0, (double)sleepNs / 1000000.0,
-                  __atomic_load_n(&artsCounterTimeOffset, __ATOMIC_RELAXED));
-        nanosleep((const struct timespec[]){{sleepNs / 1000000000,
-                                             sleepNs % 1000000000}},
-                  NULL);
-        // Advance to the next expected capture time
-        nextCaptureTime += intervalNs;
-      } else {
-        // We are late: nextCaptureTime is already in the past.
-        // Compute how many intervals we are behind and jump forward
-        // to the next future aligned capture time to avoid drift.
-        uint64_t intervalsBehind =
-            (uint64_t)(((-sleepNs) / (int64_t)intervalNs) + 1);
-        // Sanity check: cap at reasonable maximum to prevent overflow
-        if (intervalsBehind > 1000000) {
-          intervalsBehind = 1000000;
-        }
-        ARTS_INFO(
-            "Counter capture lagging: syncedTime=%lf ms, "
-            "nextCaptureTime=%lf ms, lateBy=%lf ms, skipping %lu interval(s)",
-            (double)syncedTime / 1000000.0, (double)nextCaptureTime / 1000000.0,
-            (double)(-sleepNs) / 1000000.0, intervalsBehind);
-        nextCaptureTime += intervalsBehind * intervalNs;
-      }
-    } else {
-      // Counters not yet started, wait for interval and re-check
-      nanosleep((const struct timespec[]){{intervalNs / 1000000000,
-                                           intervalNs % 1000000000}},
+    // Track current epoch for this capture
+    uint64_t currentEpoch = captureEpoch + 1;
+
+    if (sleepNs > 0) {
+      nanosleep((const struct timespec[]){{sleepNs / 1000000000,
+                                           sleepNs % 1000000000}},
                 NULL);
-      // Re-align to synced clock when counters start
-      syncedTime = artsGetSyncedTimeStamp();
-      captureEpoch = syncedTime / intervalNs;
-      nextCaptureTime = (captureEpoch + 1) * intervalNs;
-      continue;
-    }
-    // Capture counters - only for PERIODIC mode counters
-    for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-      if (artsCaptureModeArray[i] == artsCaptureModePeriodic) {
-        // Only this thread accesses node captures so no atomic needed
-        uint64_t *capture = NULL;
-        // CLUSTER level behaves like NODE level during capture
-        if (artsCaptureLevelArray[i] == artsCaptureLevelNode ||
-            artsCaptureLevelArray[i] == artsCaptureLevelCluster) {
-          capture = (uint64_t *)artsNextFreeFromArrayList(
-              artsNodeInfo.counterReduces.counterCaptures[i]);
-          if (artsCounterReduceTypes[i] == artsCounterSum) {
-            *capture = 0;
-          } else if (artsCounterReduceTypes[i] == artsCounterMax) {
-            *capture = 0;
-          } else if (artsCounterReduceTypes[i] == artsCounterMin) {
-            *capture = UINT64_MAX;
-          }
-        }
-        // Capture and reduce from all threads
-        for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
-          artsCounterCaptures *threadCapture = &artsNodeInfo.counterCaptures[t];
-          uint64_t captured =
-              artsCounterCaptureCounter(&threadCapture->counters[i]);
-          artsPushToArrayList(threadCapture->captures[i], &captured);
-          if (capture) {
-            if (artsCounterReduceTypes[i] == artsCounterSum) {
-              *capture += captured;
-            } else if (artsCounterReduceTypes[i] == artsCounterMax) {
-              if (*capture < captured) {
-                *capture = captured;
-              }
-            } else if (artsCounterReduceTypes[i] == artsCounterMin) {
-              if (*capture > captured) {
-                *capture = captured;
-              }
-            }
-          }
-        }
-      }
+      // Advance to the next expected capture time
+      captureEpoch++;
+      nextCaptureTime += intervalNs;
+    } else {
+      // We are late: nextCaptureTime is already in the past.
+      // Compute how many intervals we are behind and jump forward
+      // to the next future aligned capture time to avoid drift.
+      uint64_t intervalsBehind =
+          (uint64_t)(((-sleepNs) / (int64_t)intervalNs) + 1);
+      ARTS_INFO(
+          "Counter capture lagging: syncedTime=%lf ms, "
+          "nextCaptureTime=%lf ms, lateBy=%lf ms, skipping %lu interval(s)",
+          (double)syncedTime / 1000000.0, (double)nextCaptureTime / 1000000.0,
+          (double)(-sleepNs) / 1000000.0, intervalsBehind);
+      captureEpoch += intervalsBehind;
+      currentEpoch = captureEpoch;
+      nextCaptureTime += intervalsBehind * intervalNs;
     }
 
-// Reduce arts_id hash tables for NODE level with PERIODIC mode
-#if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
-    if ((artsCaptureModeArray[artsIdEdtMetrics] == artsCaptureModePeriodic &&
-         (artsCaptureLevelArray[artsIdEdtMetrics] == artsCaptureLevelNode ||
-          artsCaptureLevelArray[artsIdEdtMetrics] ==
-              artsCaptureLevelCluster)) ||
-        (artsCaptureModeArray[artsIdDbMetrics] == artsCaptureModePeriodic &&
-         (artsCaptureLevelArray[artsIdDbMetrics] == artsCaptureLevelNode ||
-          artsCaptureLevelArray[artsIdDbMetrics] == artsCaptureLevelCluster))) {
-      // Reduce all thread hash tables into node-level hash table
-      for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
-        artsIdReduceHashTables(
-            &artsNodeInfo.counterReduces.artsIdMetricsTable,
-            &artsNodeInfo.counterCaptures[t].artsIdMetricsTable);
+    // Capture counters from all threads - store in nodeInfo.captureArrays
+    // Skip threads with NULL liveCounters (not registered or already closed)
+    for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
+      if (artsCounterModeArray[i] == artsCounterModePeriodic) {
+        for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
+          // Read counter value from thread's __thread storage via liveCounters
+          // pointer NULL means thread hasn't registered yet or has already
+          // closed
+          artsCounter *threadCounters = artsNodeInfo.liveCounters[t];
+          if (!threadCounters) {
+            continue;
+          }
+          artsCounterCapture capture;
+          capture.epoch = currentEpoch;
+          capture.value = artsCounterCaptureCounter(&threadCounters[i]);
+          if (artsNodeInfo.captureArrays[t][i]) {
+            artsPushToArrayList(artsNodeInfo.captureArrays[t][i], &capture);
+          }
+        }
       }
     }
-#endif
   }
   return NULL;
 }
 
-void artsCounterStart(unsigned int startPoint) {
-  if (artsNodeInfo.counterStartPoint == startPoint) {
-    if (countersOn) {
-      ARTS_DEBUG("Trying to start counters which are already started at %lu",
-                 countersOn);
-      artsDebugGenerateSegFault();
-    }
-    countersOn = artsGetTimeStamp();
-
-    bool needCaptureThread = false;
-    bool hasNodeLevel = false;
-
-    for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-      // Need capture thread for PERIODIC mode counters
-      if (artsCaptureModeArray[i] == artsCaptureModePeriodic) {
-        needCaptureThread = true;
-        if (artsCaptureLevelArray[i] == artsCaptureLevelNode) {
-          hasNodeLevel = true;
-        }
-      }
-    }
-
-    if (needCaptureThread) {
-      // Time synchronization across nodes using RTT-based algorithm:
-      // Worker nodes initiate sync requests to master (rank 0).
-      // Master responds with its timestamp.
-      // Worker calculates offset accounting for network latency.
-      //
-      // Algorithm (NTP-like):
-      //   T1 = worker send time (worker clock)
-      //   T2 = master receive time (master clock)
-      //   T3 = worker receive time (worker clock)
-      //   RTT = T3 - T1 (clock offsets cancel)
-      //   offset = ((T1 - T2) + (T3 - T2)) / 2
-      //          = (T1 + T3) / 2 - T2
-      // This assumes symmetric network latency.
-
-      if (artsGlobalRankId == 0) {
-        // Master node: no offset needed, just mark as synced
-        __atomic_store_n(&artsCounterTimeOffset, 0, __ATOMIC_RELAXED);
-        __atomic_store_n(&artsCounterTimeSyncReceived, true, __ATOMIC_RELEASE);
-        ARTS_INFO("Time sync: Master node (rank 0), offset=0");
-      } else {
-        // Worker nodes: send sync request to master and wait for response
-        artsRemoteTimeSyncReqSend(0); // Send to master (rank 0)
-
-        // Wait for sync response with timeout
-        uint64_t timeout = artsGetTimeStamp() + 5000000000ULL; // 5 seconds
-        while (!__atomic_load_n(&artsCounterTimeSyncReceived, __ATOMIC_ACQUIRE) &&
-               artsGetTimeStamp() < timeout) {
-          usleep(1000); // Wait 1ms
-        }
-        if (!__atomic_load_n(&artsCounterTimeSyncReceived, __ATOMIC_ACQUIRE)) {
-          ARTS_INFO("Time sync: Timeout waiting for master response, "
-                    "using local time (offset=0)");
-          __atomic_store_n(&artsCounterTimeOffset, 0, __ATOMIC_RELAXED);
-          __atomic_store_n(&artsCounterTimeSyncReceived, true, __ATOMIC_RELEASE);
-        }
-      }
-
-      captureThreadRunning = true;
-
-      int ret = pthread_create(&captureThread, NULL, artsCounterCaptureThread,
-                               artsThreadInfo.artsCounters);
-      if (ret) {
-        ARTS_DEBUG("Failed to create capture thread: %d", ret);
-        captureThreadRunning = false;
-      } else {
-        ARTS_INFO("Counter capture thread started (THREAD=%s, NODE=%s)",
-                  needCaptureThread ? "yes" : "no",
-                  hasNodeLevel ? "yes" : "no");
-      }
-    }
-  }
-}
-
-void artsCounterStop() {
-  uint64_t temp = countersOn;
-  countersOn = 0;
-  if (temp == 0) {
-    ARTS_DEBUG("Trying to stop counters which are not started");
+void artsCounterCaptureStart() {
+  if (captureThreadRunning) {
+    ARTS_DEBUG("Trying to start capture thread which is already running");
     artsDebugGenerateSegFault();
   }
 
-  if (captureThreadRunning) {
-    captureThreadRunning = false;
-    int ret = pthread_join(captureThread, NULL);
-    if (ret) {
-      ARTS_DEBUG("Failed to join capture thread: %d", ret);
-    } else {
-      ARTS_INFO("Counter capture thread stopped");
+  bool needCaptureThread = false;
+
+  for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
+    // Need capture thread for PERIODIC mode counters
+    if (artsCounterModeArray[i] == artsCounterModePeriodic) {
+      needCaptureThread = true;
+      break;
     }
   }
 
-  ARTS_INFO("Counter on time: %lu", artsGetTimeStamp() - temp);
+  if (needCaptureThread) {
+    // RTT-based time synchronization: workers send request to master,
+    // master responds with its timestamp, workers calculate offset using RTT.
+    // This provides better accuracy than one-way broadcast.
+
+    if (artsGlobalRankId == 0) {
+      // Master node: no offset needed, just set ready
+      artsCounterTimeOffset = 0;
+      artsCounterTimeSyncReceived = true;
+      ARTS_INFO("Time sync: Master node (rank 0), offset=0");
+    } else {
+      // Worker nodes: send sync request and wait for response
+      artsRemoteTimeSyncRequest();
+      uint64_t timeout = artsGetTimeStamp() + 1000000000ULL; // 1 second
+      while (!artsCounterTimeSyncReceived && artsGetTimeStamp() < timeout) {
+        usleep(1000); // Wait 1ms
+      }
+      if (!artsCounterTimeSyncReceived) {
+        ARTS_INFO("Time sync: Timeout waiting for master response, "
+                  "using local time (offset=0)");
+        artsCounterTimeOffset = 0;
+        artsCounterTimeSyncReceived = true;
+      }
+    }
+
+    captureThreadRunning = true;
+
+    int ret =
+        pthread_create(&captureThread, NULL, artsCounterCaptureThread, NULL);
+    if (ret) {
+      ARTS_DEBUG("Failed to create capture thread: %d", ret);
+      captureThreadRunning = false;
+    } else {
+      ARTS_INFO("Counter capture thread started");
+    }
+  }
 }
 
-void artsCounterReset(artsCounter *counter) {
-  counter->count = 0;
-  counter->start = 0;
+void artsCounterCaptureStop() {
+  if (!captureThreadRunning) {
+    // No capture thread to stop - this is fine, counters still work
+    return;
+  }
+  captureThreadRunning = false;
+  int ret = pthread_join(captureThread, NULL);
+  if (ret) {
+    ARTS_DEBUG("Failed to join capture thread: %d", ret);
+  }
 }
 
 void artsCounterIncrementBy(artsCounter *counter, uint64_t num) {
-  if (countersOn) {
-    artsAtomicFetchAddU64(&counter->count, num);
-  }
+  artsAtomicFetchAddU64(&counter->count, num);
 }
 
 void artsCounterDecrementBy(artsCounter *counter, uint64_t num) {
-  if (countersOn) {
-    artsAtomicFetchSubU64(&counter->count, num);
-  }
+  artsAtomicFetchSubU64(&counter->count, num);
 }
 
 void artsCounterTimerStart(artsCounter *counter) {
-  if (countersOn) {
-    if (artsAtomicCswapU64(&counter->start, 0, artsGetTimeStamp())) {
-      ARTS_DEBUG("Trying to start a timer that is already started");
-      artsDebugGenerateSegFault();
-    }
+  if (artsAtomicCswapU64(&counter->start, 0, artsGetTimeStamp())) {
+    ARTS_DEBUG("Trying to start a timer that is already started");
+    artsDebugGenerateSegFault();
   }
 }
 
 void artsCounterTimerEnd(artsCounter *counter) {
-  if (countersOn) {
-    uint64_t end = artsGetTimeStamp();
-    uint64_t start = artsAtomicSwapU64(&counter->start, 0);
-    if (!start) {
-      ARTS_DEBUG("Trying to end a timer that is not started");
-      artsDebugGenerateSegFault();
-    }
-    artsAtomicFetchAddU64(&counter->count, end - start);
+  uint64_t end = artsGetTimeStamp();
+  uint64_t start = artsAtomicSwapU64(&counter->start, 0);
+  if (!start) {
+    ARTS_DEBUG("Trying to end a timer that is not started");
+    artsDebugGenerateSegFault();
+  }
+  artsAtomicFetchAddU64(&counter->count, end - start);
+}
+
+// Helper: apply one reduction step
+static inline uint64_t artsApplyReduction(uint64_t accumulator, uint64_t value,
+                                          artsCounterReduceMethod reduceMethod,
+                                          unsigned int sourceIndex) {
+  switch (reduceMethod) {
+  case artsCounterReduceSum:
+    return accumulator + value;
+  case artsCounterReduceMax:
+    return (accumulator < value) ? value : accumulator;
+  case artsCounterReduceMin:
+    return (accumulator > value) ? value : accumulator;
+  case artsCounterReduceMaster:
+    return (sourceIndex == 0) ? value : accumulator;
+  }
+  return accumulator;
+}
+
+// Helper: convert reduce method to string for JSON output
+static inline const char *
+artsReduceMethodToString(artsCounterReduceMethod reduceMethod) {
+  switch (reduceMethod) {
+  case artsCounterReduceSum:
+    return "SUM";
+  case artsCounterReduceMax:
+    return "MAX";
+  case artsCounterReduceMin:
+    return "MIN";
+  case artsCounterReduceMaster:
+    return "MASTER";
+  }
+  return "SUM";
+}
+
+// Helper: convert capture mode to string for JSON output
+static inline const char *artsCounterModeToString(unsigned int mode) {
+  switch (mode) {
+  case artsCounterModeOnce:
+    return "ONCE";
+  case artsCounterModePeriodic:
+    return "PERIODIC";
+  default:
+    return "OFF";
   }
 }
 
-void artsCounterWriteThread(const char *outputFolder, unsigned int nodeId,
-                            unsigned int threadId) {
-  if (!outputFolder) {
-    return;
-  }
-
-  // Check if any counters have THREAD level output
-  bool hasThreadLevel = false;
-  for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-    if (artsCaptureModeArray[i] != artsCaptureModeOff &&
-        artsCaptureLevelArray[i] == artsCaptureLevelThread) {
-      hasThreadLevel = true;
-      break;
+// Helper: check if counter name contains "Time" (case-insensitive)
+static bool artsCounterIsTimeCounter(const char *name) {
+  if (!name)
+    return false;
+  const char *p = name;
+  while (*p) {
+    if ((*p == 'T' || *p == 't') && (*(p + 1) == 'I' || *(p + 1) == 'i') &&
+        (*(p + 2) == 'M' || *(p + 2) == 'm') &&
+        (*(p + 3) == 'E' || *(p + 3) == 'e')) {
+      return true;
     }
+    p++;
   }
-  if (!hasThreadLevel) {
-    return;
-  }
+  return false;
+}
 
-  struct stat st = {0};
-  if (stat(outputFolder, &st) == -1)
-    mkdir(outputFolder, 0755);
-
-  char filename[1024];
-  snprintf(filename, sizeof(filename), "%s/n%u_t%u.json", outputFolder, nodeId,
-           threadId);
-
-  FILE *fp = fopen(filename, "w");
-  if (!fp)
+// Helper: write capture history array to JSON as compact single line
+// Format: [[epoch, value], [epoch, value], ...]
+// Epochs are normalized to start from 0 by subtracting firstCaptureEpoch
+static void artsWriteCaptureHistory(artsJsonWriter *writer, uint64_t *epochs,
+                                    uint64_t *values, uint64_t count) {
+  if (count == 0)
     return;
 
-  artsJsonWriter writer;
-  artsJsonWriterInit(&writer, fp, 2);
+  // Build compact JSON string: [[e,v],[e,v],...]
+  // Estimate size: each entry is at most ~40 chars, plus brackets
+  size_t bufSize = count * 45 + 10;
+  char *buf = (char *)artsMalloc(bufSize);
+  char *p = buf;
+  *p++ = '[';
 
-  artsJsonWriterBeginObject(&writer, NULL);
+  for (uint64_t c = 0; c < count; c++) {
+    if (c > 0)
+      *p++ = ',';
+    uint64_t normalizedEpoch = epochs[c] - firstCaptureEpoch;
+    p += sprintf(p, "[%llu,%llu]", (unsigned long long)normalizedEpoch,
+                 (unsigned long long)values[c]);
+  }
+  *p++ = ']';
+  *p = '\0';
 
-  artsJsonWriterBeginObject(&writer, "metadata");
-  artsJsonWriterWriteUInt64(&writer, "nodeId", nodeId);
-  artsJsonWriterWriteUInt64(&writer, "threadId", threadId);
-  artsJsonWriterWriteUInt64(&writer, "timestamp", (uint64_t)time(NULL));
-  artsJsonWriterWriteString(&writer, "version", "1.0");
-  artsJsonWriterWriteUInt64(&writer, "startPoint",
-                            artsNodeInfo.counterStartPoint);
+  artsJsonWriterWriteRawArray(writer, "captureHistory", buf);
+  artsFree(buf);
+}
+
+// Helper: write common metadata fields to JSON
+static void artsWriteCommonMetadata(artsJsonWriter *writer) {
+  artsJsonWriterWriteUInt64(writer, "timestamp", (uint64_t)time(NULL));
+  artsJsonWriterWriteString(writer, "version", "1.7.0");
   if (artsNodeInfo.counterFolder) {
-    artsJsonWriterWriteString(&writer, "counterFolder",
+    artsJsonWriterWriteString(writer, "counterFolder",
                               artsNodeInfo.counterFolder);
   }
-  artsJsonWriterWriteUInt64(&writer, "counterCaptureInterval",
-                            artsNodeInfo.counterCaptureInterval);
-  artsJsonWriterEndObject(&writer);
+}
 
-  artsJsonWriterBeginObject(&writer, "counters");
-  artsCounterCaptures *threadCounters = &artsNodeInfo.counterCaptures[threadId];
-  for (uint64_t i = 0; i < NUM_COUNTER_TYPES; i++) {
-    // Write counters with THREAD level (both ONCE and PERIODIC modes)
-    if (artsCaptureModeArray[i] != artsCaptureModeOff &&
-        artsCaptureLevelArray[i] == artsCaptureLevelThread) {
-      artsCounter *counter = &threadCounters->counters[i];
-      artsJsonWriterBeginObject(&writer, artsCounterNames[i]);
-      artsJsonWriterWriteUInt64(&writer, "count", counter->count);
-
-      // Write capture mode and level information
-      const char *captureModeStr = "OFF";
-      switch (artsCaptureModeArray[i]) {
-      case artsCaptureModeOnce:
-        captureModeStr = "ONCE";
-        break;
-      case artsCaptureModePeriodic:
-        captureModeStr = "PERIODIC";
-        break;
-      default:
-        break;
-      }
-      artsJsonWriterWriteString(&writer, "captureMode", captureModeStr);
-      artsJsonWriterWriteString(&writer, "captureLevel", "THREAD");
-
-      // Write capture history only for PERIODIC mode
-      if (artsCaptureModeArray[i] == artsCaptureModePeriodic) {
-        artsArrayList *captureList = threadCounters->captures[i];
-        if (captureList && captureList->index > 0) {
-          artsJsonWriterWriteUInt64(&writer, "captureCount",
-                                    captureList->index);
-          artsJsonWriterBeginArray(&writer, "captureHistory");
-          artsArrayListIterator *iter = artsNewArrayListIterator(captureList);
-          while (artsArrayListHasNext(iter)) {
-            uint64_t *value = (uint64_t *)artsArrayListNext(iter);
-            if (value) {
-              artsJsonWriterWriteUInt64(&writer, NULL, *value);
-            }
-          }
-          artsDeleteArrayListIterator(iter);
-          artsJsonWriterEndArray(&writer);
-        }
-      }
-
-      artsJsonWriterEndObject(&writer);
+// Helper: check if any counters exist at given level, return count
+static unsigned int artsCountersAtLevel(unsigned int level) {
+  unsigned int count = 0;
+  for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
+    if (artsCounterModeArray[i] != artsCounterModeOff &&
+        artsCounterLevelArray[i] == level) {
+      count++;
     }
   }
-  artsJsonWriterEndObject(&writer);
+  return count;
+}
 
-// Write arts_id metrics (THREAD level)
-#if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
-  if ((artsCaptureModeArray[artsIdEdtMetrics] != artsCaptureModeOff &&
-       artsCaptureLevelArray[artsIdEdtMetrics] == artsCaptureLevelThread) ||
-      (artsCaptureModeArray[artsIdDbMetrics] != artsCaptureModeOff &&
-       artsCaptureLevelArray[artsIdDbMetrics] == artsCaptureLevelThread)) {
-    artsJsonWriterBeginObject(&writer, "artsIdMetrics");
-    artsIdHashTable *table =
-        &artsNodeInfo.counterCaptures[threadId].artsIdMetricsTable;
-
-    // Export EDT metrics
-    if (artsCounterMode[artsIdEdtMetrics] == artsCounterModeThread) {
-      artsJsonWriterBeginArray(&writer, "edts");
-      for (uint32_t i = 0; i < ARTS_ID_HASH_SIZE; i++) {
-        if (table->edt_metrics[i].valid) {
-          artsJsonWriterBeginObject(&writer, NULL);
-          artsJsonWriterWriteUInt64(&writer, "arts_id",
-                                    table->edt_metrics[i].arts_id);
-          artsJsonWriterWriteUInt64(&writer, "invocations",
-                                    table->edt_metrics[i].invocations);
-          artsJsonWriterWriteUInt64(&writer, "total_exec_ns",
-                                    table->edt_metrics[i].total_exec_ns);
-          artsJsonWriterWriteUInt64(&writer, "total_stall_ns",
-                                    table->edt_metrics[i].total_stall_ns);
-          artsJsonWriterEndObject(&writer);
-        }
-      }
-      artsJsonWriterEndArray(&writer);
-      artsJsonWriterWriteUInt64(&writer, "edt_collisions",
-                                table->edt_collisions);
-    }
-
-    // Export DB metrics
-    if (artsCounterMode[artsIdDbMetrics] == artsCounterModeThread) {
-      artsJsonWriterBeginArray(&writer, "dbs");
-      for (uint32_t i = 0; i < ARTS_ID_HASH_SIZE; i++) {
-        if (table->db_metrics[i].valid) {
-          artsJsonWriterBeginObject(&writer, NULL);
-          artsJsonWriterWriteUInt64(&writer, "arts_id",
-                                    table->db_metrics[i].arts_id);
-          artsJsonWriterWriteUInt64(&writer, "invocations",
-                                    table->db_metrics[i].invocations);
-          artsJsonWriterWriteUInt64(&writer, "bytes_local",
-                                    table->db_metrics[i].bytes_local);
-          artsJsonWriterWriteUInt64(&writer, "bytes_remote",
-                                    table->db_metrics[i].bytes_remote);
-          artsJsonWriterWriteUInt64(&writer, "cache_misses",
-                                    table->db_metrics[i].cache_misses);
-          artsJsonWriterEndObject(&writer);
-        }
-      }
-      artsJsonWriterEndArray(&writer);
-      artsJsonWriterWriteUInt64(&writer, "db_collisions", table->db_collisions);
-    }
-
-    artsJsonWriterEndObject(&writer);
+// Helper: open output file, creating directory if needed
+static FILE *artsOpenCounterFile(const char *outputFolder,
+                                 const char *filename) {
+  struct stat st = {0};
+  if (stat(outputFolder, &st) == -1) {
+    mkdir(outputFolder, 0755);
   }
-#endif
+  char filepath[1024];
+  snprintf(filepath, sizeof(filepath), "%s/%s", outputFolder, filename);
+  return fopen(filepath, "w");
+}
 
-  artsJsonWriterEndObject(&writer);
-  artsJsonWriterFinish(&writer);
+// Helper: finalize and close JSON file
+static void artsCloseCounterFile(artsJsonWriter *writer, FILE *fp) {
+  artsJsonWriterEndObject(writer);
+  artsJsonWriterFinish(writer);
   fputc('\n', fp);
   fclose(fp);
 }
 
-void artsCounterWriteNode(const char *outputFolder, unsigned int nodeId) {
-  if (!outputFolder) {
-    return;
+// Helper function to compute node-level reduced value across all threads
+// Safe to call after threads have closed - uses savedCounters data
+static uint64_t artsComputeNodeReducedValue(unsigned int index) {
+  artsCounterReduceMethod reduceMethod = artsCounterReduceMethodArray[index];
+  uint64_t nodeValue = (reduceMethod == artsCounterReduceMin) ? UINT64_MAX : 0;
+  for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
+    artsCounter *saved = artsNodeInfo.savedCounters[t];
+    if (!saved) {
+      continue; // Thread never registered or data not available
+    }
+    nodeValue =
+        artsApplyReduction(nodeValue, saved[index].count, reduceMethod, t);
   }
+  return nodeValue;
+}
 
-  // Check if any counters have NODE level output
-  bool hasNodeLevel = false;
-  for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-    if (artsCaptureModeArray[i] != artsCaptureModeOff &&
-        artsCaptureLevelArray[i] == artsCaptureLevelNode) {
-      hasNodeLevel = true;
-      break;
+// Helper function to compute node-level reduced captures for PERIODIC mode
+// Returns arrays of epochs and values, sets count. Caller must free both.
+static void artsComputeNodeReducedCaptures(unsigned int counterIndex,
+                                           uint64_t **outEpochs,
+                                           uint64_t **outValues,
+                                           uint64_t *outCount) {
+  *outEpochs = NULL;
+  *outValues = NULL;
+  *outCount = 0;
+
+  // Find the max number of captures across all threads
+  uint64_t maxCaptures = 0;
+  for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
+    artsArrayList *threadList = artsNodeInfo.captureArrays[t][counterIndex];
+    if (threadList && threadList->index > maxCaptures) {
+      maxCaptures = threadList->index;
     }
   }
-  if (!hasNodeLevel) {
+
+  if (maxCaptures == 0) {
     return;
   }
 
-  struct stat st = {0};
-  if (stat(outputFolder, &st) == -1)
-    mkdir(outputFolder, 0755);
+  // Allocate output arrays (upper bound size)
+  *outEpochs = (uint64_t *)artsMalloc(maxCaptures * sizeof(uint64_t));
+  *outValues = (uint64_t *)artsMalloc(maxCaptures * sizeof(uint64_t));
 
-  char filename[1024];
-  snprintf(filename, sizeof(filename), "%s/n%u.json", outputFolder, nodeId);
+  // Create iterators for all threads
+  artsArrayListIterator **iters = (artsArrayListIterator **)artsCalloc(
+      artsNodeInfo.totalThreadCount, sizeof(artsArrayListIterator *));
+  artsCounterCapture **currentCaptures = (artsCounterCapture **)artsCalloc(
+      artsNodeInfo.totalThreadCount, sizeof(artsCounterCapture *));
 
-  FILE *fp = fopen(filename, "w");
+  for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
+    artsArrayList *threadList = artsNodeInfo.captureArrays[t][counterIndex];
+    if (threadList && threadList->index > 0) {
+      iters[t] = artsNewArrayListIterator(threadList);
+      if (artsArrayListHasNext(iters[t])) {
+        currentCaptures[t] = (artsCounterCapture *)artsArrayListNext(iters[t]);
+      }
+    }
+  }
+
+  // Reduce by epoch - process captures in epoch order
+  uint64_t capturesWritten = 0;
+  while (capturesWritten < maxCaptures) {
+    // Find minimum epoch among all current captures
+    uint64_t minEpoch = UINT64_MAX;
+    for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
+      if (currentCaptures[t] && currentCaptures[t]->epoch < minEpoch) {
+        minEpoch = currentCaptures[t]->epoch;
+      }
+    }
+    if (minEpoch == UINT64_MAX)
+      break;
+
+    // Reduce all captures at this epoch
+    artsCounterReduceMethod reduceMethod =
+        artsCounterReduceMethodArray[counterIndex];
+    uint64_t reducedValue =
+        (reduceMethod == artsCounterReduceMin) ? UINT64_MAX : 0;
+    bool hasValue = false;
+    for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
+      if (currentCaptures[t] && currentCaptures[t]->epoch == minEpoch) {
+        hasValue = true;
+        reducedValue = artsApplyReduction(
+            reducedValue, currentCaptures[t]->value, reduceMethod, t);
+        // Advance this thread's iterator
+        if (artsArrayListHasNext(iters[t])) {
+          currentCaptures[t] =
+              (artsCounterCapture *)artsArrayListNext(iters[t]);
+        } else {
+          currentCaptures[t] = NULL;
+        }
+      }
+    }
+
+    if (hasValue) {
+      (*outEpochs)[capturesWritten] = minEpoch;
+      (*outValues)[capturesWritten] = reducedValue;
+      capturesWritten++;
+    }
+  }
+
+  *outCount = capturesWritten;
+
+  // Cleanup iterators
+  for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
+    if (iters[t]) {
+      artsDeleteArrayListIterator(iters[t]);
+    }
+  }
+  artsFree(iters);
+  artsFree(currentCaptures);
+}
+
+// Helper: write arts_id metrics to JSON
+#if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
+static void artsWriteArtsIdMetrics(artsJsonWriter *writer,
+                                   artsIdHashTable *table, bool writeEdt,
+                                   bool writeDb) {
+  artsJsonWriterBeginObject(writer, "artsIdMetrics");
+
+  if (writeEdt) {
+    artsJsonWriterBeginArray(writer, "edts");
+    for (uint32_t i = 0; i < ARTS_ID_HASH_SIZE; i++) {
+      if (table->edt_metrics[i].valid) {
+        artsJsonWriterBeginObject(writer, NULL);
+        artsJsonWriterWriteUInt64(writer, "arts_id",
+                                  table->edt_metrics[i].arts_id);
+        artsJsonWriterWriteUInt64(writer, "invocations",
+                                  table->edt_metrics[i].invocations);
+        artsJsonWriterWriteUInt64(writer, "total_exec_ns",
+                                  table->edt_metrics[i].total_exec_ns);
+        artsJsonWriterWriteUInt64(writer, "total_stall_ns",
+                                  table->edt_metrics[i].total_stall_ns);
+        artsJsonWriterEndObject(writer);
+      }
+    }
+    artsJsonWriterEndArray(writer);
+    artsJsonWriterWriteUInt64(writer, "edt_collisions", table->edt_collisions);
+  }
+
+  if (writeDb) {
+    artsJsonWriterBeginArray(writer, "dbs");
+    for (uint32_t i = 0; i < ARTS_ID_HASH_SIZE; i++) {
+      if (table->db_metrics[i].valid) {
+        artsJsonWriterBeginObject(writer, NULL);
+        artsJsonWriterWriteUInt64(writer, "arts_id",
+                                  table->db_metrics[i].arts_id);
+        artsJsonWriterWriteUInt64(writer, "invocations",
+                                  table->db_metrics[i].invocations);
+        artsJsonWriterWriteUInt64(writer, "bytes_local",
+                                  table->db_metrics[i].bytes_local);
+        artsJsonWriterWriteUInt64(writer, "bytes_remote",
+                                  table->db_metrics[i].bytes_remote);
+        artsJsonWriterWriteUInt64(writer, "cache_misses",
+                                  table->db_metrics[i].cache_misses);
+        artsJsonWriterEndObject(writer);
+      }
+    }
+    artsJsonWriterEndArray(writer);
+    artsJsonWriterWriteUInt64(writer, "db_collisions", table->db_collisions);
+  }
+
+  artsJsonWriterEndObject(writer);
+}
+#endif
+
+static void artsCounterWriteThread(const char *outputFolder,
+                                   unsigned int nodeId, unsigned int threadId) {
+  if (!artsCountersAtLevel(artsCounterLevelThread))
+    return;
+
+  char filename[64];
+  snprintf(filename, sizeof(filename), "n%u_t%u.json", nodeId, threadId);
+  FILE *fp = artsOpenCounterFile(outputFolder, filename);
   if (!fp)
     return;
 
   artsJsonWriter writer;
   artsJsonWriterInit(&writer, fp, 2);
-
   artsJsonWriterBeginObject(&writer, NULL);
 
+  // Metadata
   artsJsonWriterBeginObject(&writer, "metadata");
   artsJsonWriterWriteUInt64(&writer, "nodeId", nodeId);
-  artsJsonWriterWriteUInt64(&writer, "timestamp", (uint64_t)time(NULL));
-  artsJsonWriterWriteString(&writer, "version", "1.0");
-  artsJsonWriterWriteUInt64(&writer, "startPoint",
-                            artsNodeInfo.counterStartPoint);
-  if (artsNodeInfo.counterFolder) {
-    artsJsonWriterWriteString(&writer, "counterFolder",
-                              artsNodeInfo.counterFolder);
+  artsJsonWriterWriteUInt64(&writer, "threadId", threadId);
+  artsWriteCommonMetadata(&writer);
+  artsJsonWriterWriteUInt64(&writer, "counterCaptureInterval",
+                            artsNodeInfo.counterCaptureInterval);
+  artsJsonWriterEndObject(&writer);
+
+  // Counters
+  artsJsonWriterBeginObject(&writer, "counters");
+  artsCounter *saved = artsNodeInfo.savedCounters[threadId];
+  for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
+    if (artsCounterModeArray[i] == artsCounterModeOff ||
+        artsCounterLevelArray[i] != artsCounterLevelThread)
+      continue;
+
+    artsJsonWriterBeginObject(&writer, artsCounterNames[i]);
+    artsJsonWriterWriteString(&writer, "captureMode",
+                              artsCounterModeToString(artsCounterModeArray[i]));
+    artsJsonWriterWriteString(&writer, "captureLevel", "THREAD");
+
+    // Always write final value
+    uint64_t finalValue = saved[i].count;
+    artsJsonWriterWriteUInt64(&writer, "value", finalValue);
+    if (artsCounterIsTimeCounter(artsCounterNames[i])) {
+      artsJsonWriterWriteDouble(&writer, "value_ms",
+                                (double)finalValue / 1000000.0);
+    }
+
+    if (artsCounterModeArray[i] == artsCounterModePeriodic) {
+      artsArrayList *captureList = artsNodeInfo.captureArrays[threadId][i];
+      if (captureList && captureList->index > 0) {
+        uint64_t count = captureList->index;
+        uint64_t *epochs = (uint64_t *)artsMalloc(count * sizeof(uint64_t));
+        uint64_t *values = (uint64_t *)artsMalloc(count * sizeof(uint64_t));
+        artsArrayListIterator *iter = artsNewArrayListIterator(captureList);
+        for (uint64_t idx = 0; artsArrayListHasNext(iter) && idx < count;
+             idx++) {
+          artsCounterCapture *cap =
+              (artsCounterCapture *)artsArrayListNext(iter);
+          if (cap) {
+            epochs[idx] = cap->epoch;
+            values[idx] = cap->value;
+          }
+        }
+        artsDeleteArrayListIterator(iter);
+        artsWriteCaptureHistory(&writer, epochs, values, count);
+        artsFree(epochs);
+        artsFree(values);
+      }
+    }
+    artsJsonWriterEndObject(&writer);
   }
+  artsJsonWriterEndObject(&writer);
+
+#if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
+  bool edtThread =
+      artsCounterModeArray[artsIdEdtMetrics] != artsCounterModeOff &&
+      artsCounterLevelArray[artsIdEdtMetrics] == artsCounterLevelThread;
+  bool dbThread =
+      artsCounterModeArray[artsIdDbMetrics] != artsCounterModeOff &&
+      artsCounterLevelArray[artsIdDbMetrics] == artsCounterLevelThread;
+  if (edtThread || dbThread) {
+    artsWriteArtsIdMetrics(
+        &writer, &artsNodeInfo.savedCounters[threadId]->artsIdMetricsTable,
+        edtThread, dbThread);
+  }
+#endif
+
+  artsCloseCounterFile(&writer, fp);
+}
+
+static void artsCounterWriteNode(const char *outputFolder,
+                                 unsigned int nodeId) {
+  if (!artsCountersAtLevel(artsCounterLevelNode))
+    return;
+
+  char filename[64];
+  snprintf(filename, sizeof(filename), "n%u.json", nodeId);
+  FILE *fp = artsOpenCounterFile(outputFolder, filename);
+  if (!fp)
+    return;
+
+  artsJsonWriter writer;
+  artsJsonWriterInit(&writer, fp, 2);
+  artsJsonWriterBeginObject(&writer, NULL);
+
+  // Metadata
+  artsJsonWriterBeginObject(&writer, "metadata");
+  artsJsonWriterWriteUInt64(&writer, "nodeId", nodeId);
+  artsWriteCommonMetadata(&writer);
   artsJsonWriterWriteUInt64(&writer, "captureInterval",
                             artsNodeInfo.counterCaptureInterval);
   artsJsonWriterWriteUInt64(&writer, "totalThreads",
                             artsNodeInfo.totalThreadCount);
   artsJsonWriterEndObject(&writer);
 
+  // Counters
   artsJsonWriterBeginObject(&writer, "counters");
-  for (uint64_t i = 0; i < NUM_COUNTER_TYPES; i++) {
-    // Write NODE level counters (both ONCE and PERIODIC modes)
-    if (artsCaptureModeArray[i] != artsCaptureModeOff &&
-        artsCaptureLevelArray[i] == artsCaptureLevelNode) {
+  for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
+    if (artsCounterModeArray[i] == artsCounterModeOff ||
+        artsCounterLevelArray[i] != artsCounterLevelNode)
+      continue;
 
-      artsJsonWriterBeginObject(&writer, artsCounterNames[i]);
+    artsJsonWriterBeginObject(&writer, artsCounterNames[i]);
+    artsJsonWriterWriteString(&writer, "captureMode",
+                              artsCounterModeToString(artsCounterModeArray[i]));
+    artsJsonWriterWriteString(&writer, "captureLevel", "NODE");
+    artsJsonWriterWriteString(
+        &writer, "reduceMethod",
+        artsReduceMethodToString(artsCounterReduceMethodArray[i]));
 
-      // Write capture mode and level
-      const char *captureModeStr = "ONCE";
-      if (artsCaptureModeArray[i] == artsCaptureModePeriodic) {
-        captureModeStr = "PERIODIC";
-      }
-      artsJsonWriterWriteString(&writer, "captureMode", captureModeStr);
-      artsJsonWriterWriteString(&writer, "captureLevel", "NODE");
-
-      // Write reduction type
-      const char *reduceTypeStr = "SUM";
-      switch (artsCounterReduceTypes[i]) {
-      case artsCounterSum:
-        reduceTypeStr = "SUM";
-        break;
-      case artsCounterMax:
-        reduceTypeStr = "MAX";
-        break;
-      case artsCounterMin:
-        reduceTypeStr = "MIN";
-        break;
-      }
-      artsJsonWriterWriteString(&writer, "reduceType", reduceTypeStr);
-
-      // Write the current (final) reduced value
-      uint64_t finalValue = 0;
-      for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
-        artsCounterCaptures *threadCounters = &artsNodeInfo.counterCaptures[t];
-        switch (artsCounterReduceTypes[i]) {
-        case artsCounterSum:
-          finalValue += threadCounters->counters[i].count;
-          break;
-        case artsCounterMax:
-          if (finalValue < threadCounters->counters[i].count) {
-            finalValue = threadCounters->counters[i].count;
-          }
-          break;
-        case artsCounterMin:
-          if (t == 0 || finalValue > threadCounters->counters[i].count) {
-            finalValue = threadCounters->counters[i].count;
-          }
-          break;
-        }
-      }
-      artsJsonWriterWriteUInt64(&writer, "value", finalValue);
-      // Also write value in milliseconds for timing counters
+    uint64_t finalValue = artsComputeNodeReducedValue(i);
+    artsJsonWriterWriteUInt64(&writer, "value", finalValue);
+    if (artsCounterIsTimeCounter(artsCounterNames[i])) {
       artsJsonWriterWriteDouble(&writer, "value_ms",
                                 (double)finalValue / 1000000.0);
-
-      // Write capture history only for PERIODIC mode
-      if (artsCaptureModeArray[i] == artsCaptureModePeriodic) {
-        artsArrayList *reduceList =
-            artsNodeInfo.counterReduces.counterCaptures[i];
-        if (reduceList && reduceList->index > 0) {
-          artsJsonWriterWriteUInt64(&writer, "captureCount", reduceList->index);
-          artsJsonWriterBeginArray(&writer, "captureHistory");
-          artsArrayListIterator *iter = artsNewArrayListIterator(reduceList);
-          while (artsArrayListHasNext(iter)) {
-            uint64_t *value = (uint64_t *)artsArrayListNext(iter);
-            if (value) {
-              artsJsonWriterWriteUInt64(&writer, NULL, *value);
-            }
-          }
-          artsDeleteArrayListIterator(iter);
-          artsJsonWriterEndArray(&writer);
-        }
-      }
-
-      artsJsonWriterEndObject(&writer);
     }
+
+    if (artsCounterModeArray[i] == artsCounterModePeriodic) {
+      uint64_t *epochs, *values, count;
+      artsComputeNodeReducedCaptures(i, &epochs, &values, &count);
+      artsWriteCaptureHistory(&writer, epochs, values, count);
+      if (epochs)
+        artsFree(epochs);
+      if (values)
+        artsFree(values);
+    }
+    artsJsonWriterEndObject(&writer);
   }
   artsJsonWriterEndObject(&writer);
 
-// Write arts_id metrics (NODE level - reduced across all threads)
 #if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
-  if ((artsCaptureModeArray[artsIdEdtMetrics] != artsCaptureModeOff &&
-       artsCaptureLevelArray[artsIdEdtMetrics] == artsCaptureLevelNode) ||
-      (artsCaptureModeArray[artsIdDbMetrics] != artsCaptureModeOff &&
-       artsCaptureLevelArray[artsIdDbMetrics] == artsCaptureLevelNode)) {
-    artsJsonWriterBeginObject(&writer, "artsIdMetrics");
-    artsIdHashTable *table = &artsNodeInfo.counterReduces.artsIdMetricsTable;
-
-    // Export reduced EDT metrics
-    if (artsCounterMode[artsIdEdtMetrics] == artsCounterModeNode) {
-      artsJsonWriterBeginArray(&writer, "edts");
-      for (uint32_t i = 0; i < ARTS_ID_HASH_SIZE; i++) {
-        if (table->edt_metrics[i].valid) {
-          artsJsonWriterBeginObject(&writer, NULL);
-          artsJsonWriterWriteUInt64(&writer, "arts_id",
-                                    table->edt_metrics[i].arts_id);
-          artsJsonWriterWriteUInt64(&writer, "invocations",
-                                    table->edt_metrics[i].invocations);
-          artsJsonWriterWriteUInt64(&writer, "total_exec_ns",
-                                    table->edt_metrics[i].total_exec_ns);
-          artsJsonWriterWriteUInt64(&writer, "total_stall_ns",
-                                    table->edt_metrics[i].total_stall_ns);
-          artsJsonWriterEndObject(&writer);
-        }
-      }
-      artsJsonWriterEndArray(&writer);
-      artsJsonWriterWriteUInt64(&writer, "edt_collisions",
-                                table->edt_collisions);
+  bool edtNode =
+      artsCounterModeArray[artsIdEdtMetrics] != artsCounterModeOff &&
+      artsCounterLevelArray[artsIdEdtMetrics] == artsCounterLevelNode;
+  bool dbNode = artsCounterModeArray[artsIdDbMetrics] != artsCounterModeOff &&
+                artsCounterLevelArray[artsIdDbMetrics] == artsCounterLevelNode;
+  if (edtNode || dbNode) {
+    // Use thread 0's metrics as representative for node level
+    // TODO: implement proper node-level reduction of arts_id metrics
+    if (artsNodeInfo.savedCounters[0]) {
+      artsWriteArtsIdMetrics(&writer,
+                             &artsNodeInfo.savedCounters[0]->artsIdMetricsTable,
+                             edtNode, dbNode);
     }
-
-    // Export reduced DB metrics
-    if (artsCounterMode[artsIdDbMetrics] == artsCounterModeNode) {
-      artsJsonWriterBeginArray(&writer, "dbs");
-      for (uint32_t i = 0; i < ARTS_ID_HASH_SIZE; i++) {
-        if (table->db_metrics[i].valid) {
-          artsJsonWriterBeginObject(&writer, NULL);
-          artsJsonWriterWriteUInt64(&writer, "arts_id",
-                                    table->db_metrics[i].arts_id);
-          artsJsonWriterWriteUInt64(&writer, "invocations",
-                                    table->db_metrics[i].invocations);
-          artsJsonWriterWriteUInt64(&writer, "bytes_local",
-                                    table->db_metrics[i].bytes_local);
-          artsJsonWriterWriteUInt64(&writer, "bytes_remote",
-                                    table->db_metrics[i].bytes_remote);
-          artsJsonWriterWriteUInt64(&writer, "cache_misses",
-                                    table->db_metrics[i].cache_misses);
-          artsJsonWriterEndObject(&writer);
-        }
-      }
-      artsJsonWriterEndArray(&writer);
-      artsJsonWriterWriteUInt64(&writer, "db_collisions", table->db_collisions);
-    }
-
-    artsJsonWriterEndObject(&writer);
   }
 #endif
 
-  artsJsonWriterEndObject(&writer);
-  artsJsonWriterFinish(&writer);
-  fputc('\n', fp);
-  fclose(fp);
+  artsCloseCounterFile(&writer, fp);
 }
 
-// Helper function to compute node-level reduced value across all threads
-static uint64_t artsComputeNodeReducedValue(unsigned int index) {
-  uint64_t nodeValue;
-  if (artsCounterReduceTypes[index] == artsCounterMin) {
-    nodeValue = UINT64_MAX;
-  } else {
-    nodeValue = 0;
-  }
-  for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
-    artsCounterCaptures *threadCounters = &artsNodeInfo.counterCaptures[t];
-    switch (artsCounterReduceTypes[index]) {
-    case artsCounterSum:
-      nodeValue += threadCounters->counters[index].count;
-      break;
-    case artsCounterMax:
-      if (nodeValue < threadCounters->counters[index].count) {
-        nodeValue = threadCounters->counters[index].count;
-      }
-      break;
-    case artsCounterMin:
-      if (nodeValue > threadCounters->counters[index].count) {
-        nodeValue = threadCounters->counters[index].count;
-      }
-      break;
-    }
-  }
-  return nodeValue;
-}
-
-void artsCounterWriteCluster(const char *outputFolder) {
-  if (!outputFolder) {
+static void artsCounterWriteCluster(const char *outputFolder) {
+  unsigned int clusterCounterCount =
+      artsCountersAtLevel(artsCounterLevelCluster);
+  if (!clusterCounterCount)
     return;
-  }
-
-  // Check if any counters have CLUSTER level output
-  bool hasClusterLevel = false;
-  for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-    if (artsCaptureModeArray[i] != artsCaptureModeOff &&
-        artsCaptureLevelArray[i] == artsCaptureLevelCluster) {
-      hasClusterLevel = true;
-      break;
-    }
-  }
-  if (!hasClusterLevel) {
-    return;
-  }
 
   unsigned int numNodes = artsGlobalRankCount;
 
-  // Only master (rank 0) writes cluster output
-  if (artsGlobalRankId != 0) {
-    // Non-master nodes send their counter values to master
+  if (artsGlobalRankId == 0) {
+    // Master: allocate, wait for workers, reduce and write
+    artsClusterCounterValues =
+        (uint64_t **)artsCalloc(NUM_COUNTER_TYPES, sizeof(uint64_t *));
+    artsClusterCaptureEpochs =
+        (uint64_t ***)artsCalloc(NUM_COUNTER_TYPES, sizeof(uint64_t **));
+    artsClusterCaptureValues =
+        (uint64_t ***)artsCalloc(NUM_COUNTER_TYPES, sizeof(uint64_t **));
+    artsClusterCaptureCounts =
+        (uint64_t **)artsCalloc(NUM_COUNTER_TYPES, sizeof(uint64_t *));
+
     for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-      if (artsCaptureModeArray[i] != artsCaptureModeOff &&
-          artsCaptureLevelArray[i] == artsCaptureLevelCluster) {
-        // Compute this node's reduced value across all threads
-        uint64_t nodeValue = artsComputeNodeReducedValue(i);
-        // Send to master
-        artsRemoteCounterReduceSend(0, i, nodeValue);
+      if (artsCounterModeArray[i] == artsCounterModeOff ||
+          artsCounterLevelArray[i] != artsCounterLevelCluster)
+        continue;
+      artsClusterCounterValues[i] =
+          (uint64_t *)artsCalloc(numNodes, sizeof(uint64_t));
+      artsClusterCaptureEpochs[i] =
+          (uint64_t **)artsCalloc(numNodes, sizeof(uint64_t *));
+      artsClusterCaptureValues[i] =
+          (uint64_t **)artsCalloc(numNodes, sizeof(uint64_t *));
+      artsClusterCaptureCounts[i] =
+          (uint64_t *)artsCalloc(numNodes, sizeof(uint64_t));
+      if (artsCounterReduceMethodArray[i] == artsCounterReduceMin) {
+        for (unsigned int n = 0; n < numNodes; n++)
+          artsClusterCounterValues[i][n] = UINT64_MAX;
       }
     }
-    // Signal master that we're done sending
-    artsRemoteCounterReduceDoneSend(0);
-    return;
-  }
 
-  // Master node code below
-
-  // Allocate cluster counter storage if not already done
-  if (!artsClusterCounters) {
-    artsClusterCounters =
-        (uint64_t *)artsCalloc(NUM_COUNTER_TYPES, sizeof(uint64_t));
-    // Initialize all counters based on reduce type for defensive safety
+    // Store master's own data
     for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-      if (artsCounterReduceTypes[i] == artsCounterMin) {
-        artsClusterCounters[i] = UINT64_MAX;
-      } else {
-        artsClusterCounters[i] = 0;
+      if (artsCounterModeArray[i] == artsCounterModeOff ||
+          artsCounterLevelArray[i] != artsCounterLevelCluster)
+        continue;
+      artsClusterCounterValues[i][0] = artsComputeNodeReducedValue(i);
+      if (artsCounterModeArray[i] == artsCounterModePeriodic) {
+        artsComputeNodeReducedCaptures(i, &artsClusterCaptureEpochs[i][0],
+                                       &artsClusterCaptureValues[i][0],
+                                       &artsClusterCaptureCounts[i][0]);
       }
     }
-  }
 
-  // First, add this node's (master's) own values to the cluster counters
-  for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-    if (artsCaptureModeArray[i] != artsCaptureModeOff &&
-        artsCaptureLevelArray[i] == artsCaptureLevelCluster) {
-      // Compute this node's reduced value across all threads
-      uint64_t nodeValue = artsComputeNodeReducedValue(i);
-      // Aggregate into cluster counters
-      switch (artsCounterReduceTypes[i]) {
-      case artsCounterSum:
-        artsClusterCounters[i] += nodeValue;
-        break;
-      case artsCounterMax:
-        if (artsClusterCounters[i] < nodeValue) {
-          artsClusterCounters[i] = nodeValue;
-        }
-        break;
-      case artsCounterMin:
-        if (artsClusterCounters[i] > nodeValue) {
-          artsClusterCounters[i] = nodeValue;
-        }
-        break;
+    // Wait for workers
+    unsigned int expectedMessages = (numNodes - 1) * clusterCounterCount;
+    if (expectedMessages > 0) {
+      uint64_t timeout = artsGetTimeStamp() + 30000000000ULL;
+      while (artsCounterReduceReceived < expectedMessages &&
+             artsGetTimeStamp() < timeout) {
+        usleep(1000);
       }
     }
-  }
 
-  // Wait for all other nodes to send their counter values
-  // numNodes - 1 because master doesn't send to itself
-  // Timeout after 30 seconds to prevent indefinite blocking
-  if (numNodes > 1) {
-    unsigned int timeoutMs = 30000; // 30 second timeout
-    uint64_t startTime = artsGetTimeStamp();
-    while (artsClusterNodesReceived < numNodes - 1) {
-      uint64_t elapsedMs =
-          (artsGetTimeStamp() - startTime) / 1000000ULL; // convert ns to ms
-      if (elapsedMs >= timeoutMs) {
-        break;
-      }
-      usleep(1000); // 1ms sleep to avoid busy waiting
-    }
-    if (artsClusterNodesReceived < numNodes - 1) {
-      ARTS_INFO("Cluster counter aggregation timed out: received %u/%u nodes",
-                artsClusterNodesReceived, numNodes - 1);
-    }
-  }
+    // Write cluster file
+    FILE *fp = artsOpenCounterFile(outputFolder, "cluster.json");
+    if (!fp)
+      goto cleanup;
 
-  // Now write the cluster output file
-  struct stat st = {0};
-  if (stat(outputFolder, &st) == -1)
-    mkdir(outputFolder, 0755);
+    artsJsonWriter writer;
+    artsJsonWriterInit(&writer, fp, 2);
+    artsJsonWriterBeginObject(&writer, NULL);
 
-  char filename[1024];
-  snprintf(filename, sizeof(filename), "%s/c.json", outputFolder);
+    artsJsonWriterBeginObject(&writer, "metadata");
+    artsJsonWriterWriteUInt64(&writer, "numNodes", numNodes);
+    artsWriteCommonMetadata(&writer);
+    artsJsonWriterWriteString(&writer, "level", "CLUSTER");
+    artsJsonWriterEndObject(&writer);
 
-  FILE *fp = fopen(filename, "w");
-  if (!fp)
-    return;
+    artsJsonWriterBeginObject(&writer, "counters");
+    for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
+      if (artsCounterModeArray[i] == artsCounterModeOff ||
+          artsCounterLevelArray[i] != artsCounterLevelCluster)
+        continue;
 
-  artsJsonWriter writer;
-  artsJsonWriterInit(&writer, fp, 2);
-
-  artsJsonWriterBeginObject(&writer, NULL);
-
-  artsJsonWriterBeginObject(&writer, "metadata");
-  artsJsonWriterWriteUInt64(&writer, "numNodes", numNodes);
-  artsJsonWriterWriteUInt64(&writer, "timestamp", (uint64_t)time(NULL));
-  artsJsonWriterWriteString(&writer, "version", "1.0");
-  artsJsonWriterWriteString(&writer, "level", "CLUSTER");
-  artsJsonWriterWriteUInt64(&writer, "startPoint",
-                            artsNodeInfo.counterStartPoint);
-  if (artsNodeInfo.counterFolder) {
-    artsJsonWriterWriteString(&writer, "counterFolder",
-                              artsNodeInfo.counterFolder);
-  }
-  artsJsonWriterEndObject(&writer);
-
-  artsJsonWriterBeginObject(&writer, "counters");
-  for (uint64_t i = 0; i < NUM_COUNTER_TYPES; i++) {
-    // Write CLUSTER level counters (both ONCE and PERIODIC modes)
-    if (artsCaptureModeArray[i] != artsCaptureModeOff &&
-        artsCaptureLevelArray[i] == artsCaptureLevelCluster) {
-
+      artsCounterReduceMethod reduceMethod = artsCounterReduceMethodArray[i];
       artsJsonWriterBeginObject(&writer, artsCounterNames[i]);
-
-      // Write capture mode and level
-      const char *captureModeStr = "ONCE";
-      if (artsCaptureModeArray[i] == artsCaptureModePeriodic) {
-        captureModeStr = "PERIODIC";
-      }
-      artsJsonWriterWriteString(&writer, "captureMode", captureModeStr);
+      artsJsonWriterWriteString(
+          &writer, "captureMode",
+          artsCounterModeToString(artsCounterModeArray[i]));
       artsJsonWriterWriteString(&writer, "captureLevel", "CLUSTER");
+      artsJsonWriterWriteString(&writer, "reduceMethod",
+                                artsReduceMethodToString(reduceMethod));
 
-      // Write reduction type
-      const char *reduceTypeStr = "SUM";
-      switch (artsCounterReduceTypes[i]) {
-      case artsCounterSum:
-        reduceTypeStr = "SUM";
-        break;
-      case artsCounterMax:
-        reduceTypeStr = "MAX";
-        break;
-      case artsCounterMin:
-        reduceTypeStr = "MIN";
-        break;
+      if (artsCounterModeArray[i] == artsCounterModeOnce) {
+        uint64_t clusterValue =
+            (reduceMethod == artsCounterReduceMin) ? UINT64_MAX : 0;
+        for (unsigned int n = 0; n < numNodes; n++)
+          clusterValue = artsApplyReduction(
+              clusterValue, artsClusterCounterValues[i][n], reduceMethod, n);
+        artsJsonWriterWriteUInt64(&writer, "value", clusterValue);
+        if (artsCounterIsTimeCounter(artsCounterNames[i])) {
+          artsJsonWriterWriteDouble(&writer, "value_ms",
+                                    (double)clusterValue / 1000000.0);
+        }
+      } else {
+        // PERIODIC: first write final value, then capture history
+        uint64_t clusterValue =
+            (reduceMethod == artsCounterReduceMin) ? UINT64_MAX : 0;
+        for (unsigned int n = 0; n < numNodes; n++)
+          clusterValue = artsApplyReduction(
+              clusterValue, artsClusterCounterValues[i][n], reduceMethod, n);
+        artsJsonWriterWriteUInt64(&writer, "value", clusterValue);
+        if (artsCounterIsTimeCounter(artsCounterNames[i])) {
+          artsJsonWriterWriteDouble(&writer, "value_ms",
+                                    (double)clusterValue / 1000000.0);
+        }
+
+        // Then write capture history reduced by epoch as compact single line
+        uint64_t *nodePositions =
+            (uint64_t *)artsCalloc(numNodes, sizeof(uint64_t));
+
+        // First pass: count how many entries we'll have
+        uint64_t entryCount = 0;
+        uint64_t *tempPositions =
+            (uint64_t *)artsCalloc(numNodes, sizeof(uint64_t));
+        while (1) {
+          uint64_t minEpoch = UINT64_MAX;
+          for (unsigned int n = 0; n < numNodes; n++) {
+            if (artsClusterCaptureEpochs[i][n] &&
+                tempPositions[n] < artsClusterCaptureCounts[i][n]) {
+              uint64_t epoch = artsClusterCaptureEpochs[i][n][tempPositions[n]];
+              if (epoch < minEpoch)
+                minEpoch = epoch;
+            }
+          }
+          if (minEpoch == UINT64_MAX)
+            break;
+          unsigned int nodesWithEpoch = 0;
+          for (unsigned int n = 0; n < numNodes; n++) {
+            if (artsClusterCaptureEpochs[i][n] &&
+                tempPositions[n] < artsClusterCaptureCounts[i][n] &&
+                artsClusterCaptureEpochs[i][n][tempPositions[n]] == minEpoch) {
+              nodesWithEpoch++;
+              tempPositions[n]++;
+            }
+          }
+          if (nodesWithEpoch == numNodes)
+            entryCount++;
+        }
+        artsFree(tempPositions);
+
+        // Build compact JSON string
+        size_t bufSize = entryCount * 45 + 10;
+        char *buf = (char *)artsMalloc(bufSize);
+        char *p = buf;
+        *p++ = '[';
+        bool first = true;
+
+        while (1) {
+          uint64_t minEpoch = UINT64_MAX;
+          for (unsigned int n = 0; n < numNodes; n++) {
+            if (artsClusterCaptureEpochs[i][n] &&
+                nodePositions[n] < artsClusterCaptureCounts[i][n]) {
+              uint64_t epoch = artsClusterCaptureEpochs[i][n][nodePositions[n]];
+              if (epoch < minEpoch)
+                minEpoch = epoch;
+            }
+          }
+          if (minEpoch == UINT64_MAX)
+            break;
+
+          uint64_t reducedValue =
+              (reduceMethod == artsCounterReduceMin) ? UINT64_MAX : 0;
+          unsigned int nodesWithEpoch = 0;
+          for (unsigned int n = 0; n < numNodes; n++) {
+            if (artsClusterCaptureEpochs[i][n] &&
+                nodePositions[n] < artsClusterCaptureCounts[i][n] &&
+                artsClusterCaptureEpochs[i][n][nodePositions[n]] == minEpoch) {
+              nodesWithEpoch++;
+              reducedValue = artsApplyReduction(
+                  reducedValue,
+                  artsClusterCaptureValues[i][n][nodePositions[n]],
+                  reduceMethod, n);
+              nodePositions[n]++;
+            }
+          }
+          if (nodesWithEpoch == numNodes) {
+            if (!first)
+              *p++ = ',';
+            first = false;
+            uint64_t normalizedEpoch = minEpoch - firstCaptureEpoch;
+            p += sprintf(p, "[%llu,%llu]", (unsigned long long)normalizedEpoch,
+                         (unsigned long long)reducedValue);
+          }
+        }
+        *p++ = ']';
+        *p = '\0';
+
+        artsJsonWriterWriteRawArray(&writer, "captureHistory", buf);
+        artsFree(buf);
+        artsFree(nodePositions);
       }
-      artsJsonWriterWriteString(&writer, "reduceType", reduceTypeStr);
-
-      // Write the cluster-reduced value
-      artsJsonWriterWriteUInt64(&writer, "value", artsClusterCounters[i]);
-      // Also write value in milliseconds for timing counters
-      artsJsonWriterWriteDouble(&writer, "value_ms",
-                                (double)artsClusterCounters[i] / 1000000.0);
-
       artsJsonWriterEndObject(&writer);
     }
+    artsJsonWriterEndObject(&writer);
+    artsCloseCounterFile(&writer, fp);
+
+  cleanup:
+    for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
+      if (artsClusterCounterValues && artsClusterCounterValues[i])
+        artsFree(artsClusterCounterValues[i]);
+      if (artsClusterCaptureEpochs && artsClusterCaptureEpochs[i]) {
+        for (unsigned int n = 0; n < numNodes; n++)
+          if (artsClusterCaptureEpochs[i][n])
+            artsFree(artsClusterCaptureEpochs[i][n]);
+        artsFree(artsClusterCaptureEpochs[i]);
+      }
+      if (artsClusterCaptureValues && artsClusterCaptureValues[i]) {
+        for (unsigned int n = 0; n < numNodes; n++)
+          if (artsClusterCaptureValues[i][n])
+            artsFree(artsClusterCaptureValues[i][n]);
+        artsFree(artsClusterCaptureValues[i]);
+      }
+      if (artsClusterCaptureCounts && artsClusterCaptureCounts[i])
+        artsFree(artsClusterCaptureCounts[i]);
+    }
+    if (artsClusterCounterValues)
+      artsFree(artsClusterCounterValues);
+    if (artsClusterCaptureEpochs)
+      artsFree(artsClusterCaptureEpochs);
+    if (artsClusterCaptureValues)
+      artsFree(artsClusterCaptureValues);
+    if (artsClusterCaptureCounts)
+      artsFree(artsClusterCaptureCounts);
+    artsClusterCounterValues = NULL;
+    artsClusterCaptureEpochs = NULL;
+    artsClusterCaptureValues = NULL;
+    artsClusterCaptureCounts = NULL;
+
+  } else {
+    // Worker: compute and send to master
+    for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
+      if (artsCounterModeArray[i] == artsCounterModeOff ||
+          artsCounterLevelArray[i] != artsCounterLevelCluster)
+        continue;
+      uint64_t nodeValue = artsComputeNodeReducedValue(i);
+      if (artsCounterModeArray[i] == artsCounterModePeriodic) {
+        uint64_t *epochs, *values, count;
+        artsComputeNodeReducedCaptures(i, &epochs, &values, &count);
+        artsRemoteCounterReduceSend(i, nodeValue, epochs, values, count);
+        if (epochs)
+          artsFree(epochs);
+        if (values)
+          artsFree(values);
+      } else {
+        artsRemoteCounterReduceSend(i, nodeValue, NULL, NULL, 0);
+      }
+    }
   }
-  artsJsonWriterEndObject(&writer);
+}
 
-  artsJsonWriterEndObject(&writer);
-  artsJsonWriterFinish(&writer);
-  fputc('\n', fp);
-  fclose(fp);
+// Unified counter write function - single entry point
+void artsCounterWrite(const char *outputFolder, unsigned int nodeId,
+                      unsigned int threadId) {
+  if (!outputFolder)
+    return;
 
-  // Free the cluster counters storage
-  if (artsClusterCounters) {
-    artsFree(artsClusterCounters);
-    artsClusterCounters = NULL;
+  // Write thread-level counters for this thread
+  artsCounterWriteThread(outputFolder, nodeId, threadId);
+
+  // Thread 0 handles node and cluster level output
+  if (threadId == 0) {
+    artsCounterWriteNode(outputFolder, nodeId);
+    artsCounterWriteCluster(outputFolder);
   }
 }
 
@@ -943,11 +1044,9 @@ void artsCounterWriteCluster(const char *outputFolder) {
 void artsCounterRecordArtsIdEdt(uint64_t arts_id, uint64_t exec_ns,
                                 uint64_t stall_ns) {
 #if ENABLE_artsIdEdtMetrics
-  if (countersOn && artsCounterMode[artsIdEdtMetrics] != artsCounterModeOff) {
-    unsigned int threadId = artsThreadInfo.threadId;
-    artsIdHashTable *hash_table =
-        &artsNodeInfo.counterCaptures[threadId].artsIdMetricsTable;
-    artsIdRecordEdtMetrics(arts_id, exec_ns, stall_ns, hash_table);
+  if (artsCounterMode[artsIdEdtMetrics] != artsCounterModeOff) {
+    artsIdRecordEdtMetrics(arts_id, exec_ns, stall_ns,
+                           &artsThreadLocalArtsIdMetrics);
   }
 #else
   (void)arts_id;
@@ -959,12 +1058,9 @@ void artsCounterRecordArtsIdEdt(uint64_t arts_id, uint64_t exec_ns,
 void artsCounterRecordArtsIdDb(uint64_t arts_id, uint64_t bytes_local,
                                uint64_t bytes_remote, uint64_t cache_misses) {
 #if ENABLE_artsIdDbMetrics
-  if (countersOn && artsCounterMode[artsIdDbMetrics] != artsCounterModeOff) {
-    unsigned int threadId = artsThreadInfo.threadId;
-    artsIdHashTable *hash_table =
-        &artsNodeInfo.counterCaptures[threadId].artsIdMetricsTable;
+  if (artsCounterMode[artsIdDbMetrics] != artsCounterModeOff) {
     artsIdRecordDbMetrics(arts_id, bytes_local, bytes_remote, cache_misses,
-                          hash_table);
+                          &artsThreadLocalArtsIdMetrics);
   }
 #else
   (void)arts_id;
@@ -977,11 +1073,9 @@ void artsCounterRecordArtsIdDb(uint64_t arts_id, uint64_t bytes_local,
 void artsCounterCaptureArtsIdEdt(uint64_t arts_id, uint64_t exec_ns,
                                  uint64_t stall_ns) {
 #if ENABLE_artsIdEdtCaptures
-  if (countersOn && artsCounterMode[artsIdEdtCaptures] != artsCounterModeOff) {
-    unsigned int threadId = artsThreadInfo.threadId;
-    artsArrayList *captures =
-        artsNodeInfo.counterCaptures[threadId].artsIdEdtCaptureList;
-    artsIdCaptureEdtExecution(arts_id, exec_ns, stall_ns, captures);
+  if (artsCounterMode[artsIdEdtCaptures] != artsCounterModeOff) {
+    artsIdCaptureEdtExecution(arts_id, exec_ns, stall_ns,
+                              artsThreadLocalEdtCaptureList);
   }
 #else
   (void)arts_id;
@@ -993,11 +1087,9 @@ void artsCounterCaptureArtsIdEdt(uint64_t arts_id, uint64_t exec_ns,
 void artsCounterCaptureArtsIdDb(uint64_t arts_id, uint64_t bytes_accessed,
                                 uint8_t access_type) {
 #if ENABLE_artsIdDbCaptures
-  if (countersOn && artsCounterMode[artsIdDbCaptures] != artsCounterModeOff) {
-    unsigned int threadId = artsThreadInfo.threadId;
-    artsArrayList *captures =
-        artsNodeInfo.counterCaptures[threadId].artsIdDbCaptureList;
-    artsIdCaptureDbAccess(arts_id, bytes_accessed, access_type, captures);
+  if (artsCounterMode[artsIdDbCaptures] != artsCounterModeOff) {
+    artsIdCaptureDbAccess(arts_id, bytes_accessed, access_type,
+                          artsThreadLocalDbCaptureList);
   }
 #else
   (void)arts_id;

--- a/core/src/introspection/JsonWriter.c
+++ b/core/src/introspection/JsonWriter.c
@@ -185,6 +185,12 @@ void artsJsonWriterWriteNull(artsJsonWriter *writer, const char *key) {
   fputs("null", writer->fp);
 }
 
+void artsJsonWriterWriteRawArray(artsJsonWriter *writer, const char *key,
+                                 const char *rawJson) {
+  jsonWriterWriteKey(writer, key);
+  fputs(rawJson, writer->fp);
+}
+
 void artsJsonWriterFinish(artsJsonWriter *writer) {
   while (writer->depth)
     jsonWriterPop(writer, '}');

--- a/core/src/main.c
+++ b/core/src/main.c
@@ -36,6 +36,7 @@
 ** WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the  **
 ** License for the specific language governing permissions and limitations   **
 ******************************************************************************/
+#include "arts/introspection/Preamble.h"
 #define _GNU_SOURCE
 #define _FILE_OFFSET_BITS 64
 #include "arts/arts.h"
@@ -71,6 +72,7 @@ static inline int carts_benchmarks_should_report_init_runtime(void) {
 }
 
 int artsRT(int argc, char **argv) {
+  INITIALIZATION_TIME_START();
   uint64_t init_start_ns = carts_benchmarks_now_ns();
 
   mainArgc = argc;

--- a/core/src/runtime/Runtime.c
+++ b/core/src/runtime/Runtime.c
@@ -192,7 +192,7 @@ void artsRuntimeNodeInit(unsigned int workerThreads,
   for (unsigned int t = 0; t < totalThreads; t++) {
     // Initialize standard counter captures for PERIODIC mode counters
     for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-      if (artsCaptureModeArray[i] == artsCaptureModesPeriodic) {
+      if (artsCaptureModeArray[i] == artsCaptureModePeriodic) {
         artsNodeInfo.counterCaptures[t].captures[i] =
             artsNewArrayList(sizeof(uint64_t), 16);
       }
@@ -216,7 +216,7 @@ void artsRuntimeNodeInit(unsigned int workerThreads,
   // Initialize node-level counter reduces for PERIODIC + NODE/CLUSTER level
   // counters
   for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-    if (artsCaptureModeArray[i] == artsCaptureModesPeriodic &&
+    if (artsCaptureModeArray[i] == artsCaptureModePeriodic &&
         (artsCaptureLevelArray[i] == artsCaptureLevelNode ||
          artsCaptureLevelArray[i] == artsCaptureLevelCluster)) {
       artsNodeInfo.counterReduces.counterCaptures[i] =

--- a/core/src/runtime/Runtime.c
+++ b/core/src/runtime/Runtime.c
@@ -264,6 +264,7 @@ void artsRuntimeGlobalCleanup() {
   FINALIZATION_TIME_STOP();
 
   artsCounterStop();
+  artsCounterWriteCluster(artsNodeInfo.counterFolder);
   artsCounterWriteNode(artsNodeInfo.counterFolder, artsGlobalRankId);
   for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
     artsCounterWriteThread(artsNodeInfo.counterFolder, artsGlobalRankId, t);

--- a/core/src/runtime/Runtime.c
+++ b/core/src/runtime/Runtime.c
@@ -43,6 +43,7 @@
 #include "arts/introspection/ArtsIdCounter.h"
 #include "arts/introspection/Counter.h"
 #include "arts/introspection/Metrics.h"
+#include "arts/introspection/Preamble.h"
 #include "arts/network/Remote.h"
 #include "arts/network/RemoteProtocol.h"
 #include "arts/runtime/Globals.h"
@@ -186,67 +187,40 @@ void artsRuntimeNodeInit(unsigned int workerThreads,
   artsNodeInfo.globalGuidThreadId =
       (uint64_t *)artsCalloc(totalThreads, sizeof(uint64_t));
   artsNodeInfo.counterFolder = config->counterFolder;
-  artsNodeInfo.counterStartPoint = config->counterStartPoint;
-  artsNodeInfo.counterCaptures = (artsCounterCaptures *)artsCalloc(
-      totalThreads, sizeof(artsCounterCaptures));
+
+  // Allocate liveCounters array - pointers to each thread's __thread counters
+  // These will be registered by each thread during artsRuntimePrivateInit
+  artsNodeInfo.liveCounters =
+      (artsCounter **)artsCalloc(totalThreads, sizeof(artsCounter *));
+
+  // Allocate savedCounters - nodeInfo's own counter space for final values
+  // Pre-allocate all counters for all threads upfront
+  artsNodeInfo.savedCounters =
+      (artsCounter **)artsCalloc(totalThreads, sizeof(artsCounter *));
   for (unsigned int t = 0; t < totalThreads; t++) {
-    // Initialize standard counter captures for PERIODIC mode counters
+    artsNodeInfo.savedCounters[t] =
+        (artsCounter *)artsCalloc(NUM_COUNTER_TYPES, sizeof(artsCounter));
+  }
+
+  // Allocate captureArrays for periodic capture (capture thread writes here)
+  // Pre-allocate all ArrayLists for PERIODIC mode counters
+  artsNodeInfo.captureArrays =
+      (artsArrayList ***)artsCalloc(totalThreads, sizeof(artsArrayList **));
+  for (unsigned int t = 0; t < totalThreads; t++) {
+    artsNodeInfo.captureArrays[t] = (artsArrayList **)artsCalloc(
+        NUM_COUNTER_TYPES, sizeof(artsArrayList *));
     for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-      if (artsCaptureModeArray[i] == artsCaptureModePeriodic) {
-        artsNodeInfo.counterCaptures[t].captures[i] =
-            artsNewArrayList(sizeof(uint64_t), 16);
+      if (artsCounterModeArray[i] == artsCounterModePeriodic) {
+        artsNodeInfo.captureArrays[t][i] =
+            artsNewArrayList(sizeof(artsCounterCapture), 16);
       }
     }
-
-// Initialize arts_id tracking (integrated with counter infrastructure)
-#if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
-    artsIdInitHashTable(&artsNodeInfo.counterCaptures[t].artsIdMetricsTable);
-#endif
-#if ENABLE_artsIdEdtCaptures
-    artsNodeInfo.counterCaptures[t].artsIdEdtCaptureList =
-        artsNewArrayList(sizeof(artsIdEdtCapture), 1024);
-#endif
-#if ENABLE_artsIdDbCaptures
-    artsNodeInfo.counterCaptures[t].artsIdDbCaptureList =
-        artsNewArrayList(sizeof(artsIdDbCapture), 1024);
-#endif
   }
+
   artsNodeInfo.counterCaptureInterval = config->counterCaptureInterval;
 
-  // Initialize node-level counter reduces for PERIODIC + NODE/CLUSTER level
-  // counters
-  for (unsigned int i = 0; i < NUM_COUNTER_TYPES; i++) {
-    if (artsCaptureModeArray[i] == artsCaptureModePeriodic &&
-        (artsCaptureLevelArray[i] == artsCaptureLevelNode ||
-         artsCaptureLevelArray[i] == artsCaptureLevelCluster)) {
-      artsNodeInfo.counterReduces.counterCaptures[i] =
-          artsNewArrayList(sizeof(uint64_t), 16);
-    }
-  }
-
-// Initialize node-level arts_id reduces (for NODE level)
-#if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
-  if ((artsCaptureModeArray[artsIdEdtMetrics] != artsCaptureModeOff &&
-       artsCaptureLevelArray[artsIdEdtMetrics] == artsCaptureLevelNode) ||
-      (artsCaptureModeArray[artsIdDbMetrics] != artsCaptureModeOff &&
-       artsCaptureLevelArray[artsIdDbMetrics] == artsCaptureLevelNode)) {
-    artsIdInitHashTable(&artsNodeInfo.counterReduces.artsIdMetricsTable);
-  }
-#endif
-#if ENABLE_artsIdEdtCaptures
-  if (artsCaptureModeArray[artsIdEdtCaptures] != artsCaptureModeOff &&
-      artsCaptureLevelArray[artsIdEdtCaptures] == artsCaptureLevelNode) {
-    artsNodeInfo.counterReduces.artsIdEdtCaptureList =
-        artsNewArrayList(sizeof(artsIdEdtCapture), 1024);
-  }
-#endif
-#if ENABLE_artsIdDbCaptures
-  if (artsCaptureModeArray[artsIdDbCaptures] != artsCaptureModeOff &&
-      artsCaptureLevelArray[artsIdDbCaptures] == artsCaptureLevelNode) {
-    artsNodeInfo.counterReduces.artsIdDbCaptureList =
-        artsNewArrayList(sizeof(artsIdDbCapture), 1024);
-  }
-#endif
+  // Note: Node-level counter reduction is done at output time using
+  // savedCounters. arts_id node-level reduction also computed at output time.
 
   artsTMTNodeInit(workerThreads);
   artsInitTMTLitePerNode(workerThreads);
@@ -257,21 +231,10 @@ void artsRuntimeNodeInit(unsigned int workerThreads,
 }
 
 void artsRuntimeGlobalCleanup() {
-  // Stop end-to-end timer (main execution complete)
-  END_TO_END_TIME_STOP();
-  // Start finalization timer
-  FINALIZATION_TIME_START();
-
-  // Stop finalization timer before stopping counters
-  FINALIZATION_TIME_STOP();
-
-  artsCounterStop();
-  // Write node counters first to ensure local data is saved even if cluster
-  // aggregation fails
-  artsCounterWriteNode(artsNodeInfo.counterFolder, artsGlobalRankId);
-  artsCounterWriteCluster(artsNodeInfo.counterFolder);
+  artsCounterCaptureStop();
+  // Write all counter outputs (thread, node, and cluster levels)
   for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
-    artsCounterWriteThread(artsNodeInfo.counterFolder, artsGlobalRankId, t);
+    artsCounterWrite(artsNodeInfo.counterFolder, artsGlobalRankId, t);
   }
   artsCleanUpDbs();
   artsFree(artsNodeInfo.deque);
@@ -291,14 +254,13 @@ void artsRuntimeGlobalCleanup() {
 }
 
 void artsThreadZeroNodeStart() {
-  artsCounterStart(1);
-
-  // Start timing counters (after counters are enabled)
-  INITIALIZATION_TIME_START();
-  END_TO_END_TIME_START();
 
   setGlobalGuidOn();
   createShutdownEpoch();
+
+  artsCounterCaptureStart();
+  INITIALIZATION_TIME_STOP();
+  END_TO_END_TIME_START();
 
   if (initPerNode)
     initPerNode(artsGlobalRankId, mainArgc, mainArgv);
@@ -308,7 +270,6 @@ void artsThreadZeroNodeStart() {
 #endif
   setGuidGeneratorAfterParallelStart();
 
-  artsCounterStart(2);
   artsAtomicSub(&artsNodeInfo.readyToParallelStart, 1U);
   while (artsNodeInfo.readyToParallelStart) {
   }
@@ -323,13 +284,9 @@ void artsThreadZeroNodeStart() {
   artsAtomicSub(&artsNodeInfo.readyToInspect, 1U);
   while (artsNodeInfo.readyToInspect) {
   }
-  artsCounterStart(3);
   artsAtomicSub(&artsNodeInfo.readyToExecute, 1U);
   while (artsNodeInfo.readyToExecute) {
   }
-
-  // Stop initialization timer (initialization phase complete)
-  INITIALIZATION_TIME_STOP();
 }
 
 void artsRuntimePrivateInit(struct threadMask *unit,
@@ -400,7 +357,20 @@ void artsRuntimePrivateInit(struct threadMask *unit,
   artsThreadInfo.mallocTrace = 1;
   artsThreadInfo.localCounting = 1;
   artsThreadInfo.shadLock = 0;
-  artsThreadInfo.artsCounters = artsNodeInfo.counterCaptures[unit->id].counters;
+
+  // Register thread-local counter storage with nodeInfo
+  artsNodeInfo.liveCounters[unit->id] = artsThreadLocalCounters;
+#if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
+  artsIdInitHashTable(&artsThreadLocalArtsIdMetrics);
+#endif
+#if ENABLE_artsIdEdtCaptures
+  artsThreadLocalEdtCaptureList =
+      artsNewArrayList(sizeof(artsIdEdtCapture), 1024);
+#endif
+#if ENABLE_artsIdDbCaptures
+  artsThreadLocalDbCaptureList =
+      artsNewArrayList(sizeof(artsIdDbCapture), 1024);
+#endif
 
   artsGuidKeyGeneratorInit();
 
@@ -658,7 +628,6 @@ bool artsDefaultSchedulerLoop() {
 }
 
 int artsRuntimeLoop() {
-  TOTAL_COUNTER_START();
   if (artsThreadInfo.networkReceive) {
     while (artsThreadInfo.alive) {
       artsServerTryToReceive(&artsNodeInfo.buf, &artsNodeInfo.packetSize,
@@ -677,6 +646,5 @@ int artsRuntimeLoop() {
       artsNodeInfo.scheduler();
     }
   }
-  TOTAL_COUNTER_STOP();
   return 0;
 }

--- a/core/src/runtime/Server.c
+++ b/core/src/runtime/Server.c
@@ -356,11 +356,6 @@ void artsServerProcessPacket(struct artsRemotePacket *packet) {
     artsRemoteHandleCounterReduce(packet);
     break;
   }
-  case ARTS_REMOTE_COUNTER_REDUCE_DONE_MSG: {
-    ARTS_DEBUG("Counter Reduce Done Received");
-    artsRemoteHandleCounterReduceDone();
-    break;
-  }
   default: {
     ARTS_INFO("Unknown Packet %d %d %d", packet->messageType, packet->size,
               packet->rank);

--- a/core/src/runtime/Server.c
+++ b/core/src/runtime/Server.c
@@ -341,6 +341,26 @@ void artsServerProcessPacket(struct artsRemotePacket *packet) {
     artsRemoteHandleDbRename(packet);
     break;
   }
+  case ARTS_REMOTE_TIME_SYNC_REQ_MSG: {
+    ARTS_DEBUG("Time Sync Request Received");
+    artsRemoteHandleTimeSyncReq(packet);
+    break;
+  }
+  case ARTS_REMOTE_TIME_SYNC_RESP_MSG: {
+    ARTS_DEBUG("Time Sync Response Received");
+    artsRemoteHandleTimeSyncResp(packet);
+    break;
+  }
+  case ARTS_REMOTE_COUNTER_REDUCE_MSG: {
+    ARTS_DEBUG("Counter Reduce Received");
+    artsRemoteHandleCounterReduce(packet);
+    break;
+  }
+  case ARTS_REMOTE_COUNTER_REDUCE_DONE_MSG: {
+    ARTS_DEBUG("Counter Reduce Done Received");
+    artsRemoteHandleCounterReduceDone();
+    break;
+  }
   default: {
     ARTS_INFO("Unknown Packet %d %d %d", packet->messageType, packet->size,
               packet->rank);

--- a/core/src/runtime/compute/ShadAdapter.c
+++ b/core/src/runtime/compute/ShadAdapter.c
@@ -138,9 +138,11 @@ void artsCheckLockShad() {
   }
 }
 
-void artsStartIntroShad(unsigned int start) { artsCounterStart(start); }
+void artsStartIntroShad(unsigned int start) {
+  // artsCounterCaptureStart(start);
+}
 
-void artsStopIntroShad() { artsCounterStop(); }
+void artsStopIntroShad() { artsCounterCaptureStop(); }
 
 unsigned int artsGetShadLoopStride() { return artsNodeInfo.shadLoopStride; }
 

--- a/core/src/runtime/memory/DbFunctions.c
+++ b/core/src/runtime/memory/DbFunctions.c
@@ -491,18 +491,14 @@ void acquireDbs(struct artsEdt *edt) {
 
       // Update acquire-mode counters
       if (effectiveMode == ARTS_DB_READ) {
-        artsCounterIncrementBy(&artsThreadInfo.artsCounters[acquireReadMode],
-                               1);
+        INCREMENT_ACQUIRE_READ_MODE_BY(1);
         // Track owner update savings when override changes WRITE -> READ
         if (depv[i].mode == ARTS_DB_WRITE && owner == artsGlobalRankId)
-          artsCounterIncrementBy(
-              &artsThreadInfo.artsCounters[ownerUpdatesSaved], 1);
+          INCREMENT_OWNER_UPDATES_SAVED_BY(1);
       } else if (effectiveMode == ARTS_DB_WRITE) {
-        artsCounterIncrementBy(&artsThreadInfo.artsCounters[acquireWriteMode],
-                               1);
+        INCREMENT_ACQUIRE_WRITE_MODE_BY(1);
         if (owner == artsGlobalRankId)
-          artsCounterIncrementBy(
-              &artsThreadInfo.artsCounters[ownerUpdatesPerformed], 1);
+          INCREMENT_OWNER_UPDATES_PERFORMED_BY(1);
       }
 
       ARTS_INFO("Acquiring DB[Guid:%lu, Mode:%u, Owner:%d, Rank:%u] "

--- a/core/src/runtime/network/RemoteFunctions.c
+++ b/core/src/runtime/network/RemoteFunctions.c
@@ -1343,7 +1343,7 @@ void artsRemoteHandleCounterReduce(void *pack) {
     __sync_fetch_and_add(&artsClusterCounters[idx], value);
     break;
   case artsCounterMax: {
-    uint64_t old = artsClusterCounters[idx];
+    uint64_t old = __atomic_load_n(&artsClusterCounters[idx], __ATOMIC_RELAXED);
     while (value > old) {
       uint64_t result =
           __sync_val_compare_and_swap(&artsClusterCounters[idx], old, value);
@@ -1354,7 +1354,7 @@ void artsRemoteHandleCounterReduce(void *pack) {
     break;
   }
   case artsCounterMin: {
-    uint64_t old = artsClusterCounters[idx];
+    uint64_t old = __atomic_load_n(&artsClusterCounters[idx], __ATOMIC_RELAXED);
     while (value < old) {
       uint64_t result =
           __sync_val_compare_and_swap(&artsClusterCounters[idx], old, value);

--- a/core/src/system/Config.c
+++ b/core/src/system/Config.c
@@ -744,12 +744,6 @@ struct artsConfig *artsConfigLoad() {
   else
     config->counterFolder = artsConfigMakeNewVar("./counter");
 
-  if ((foundVariableChar = artsConfigFindVariableChar(
-           configVariables, "counterStartPoint")) != NULL)
-    config->counterStartPoint = strtol(foundVariableChar, &end, 10);
-  else
-    config->counterStartPoint = 1;
-
   if ((foundVariable = artsConfigFindVariable(
            &configVariables, "counterCaptureInterval")) != NULL)
     config->counterCaptureInterval = strtol(foundVariable->value, &end, 10);

--- a/counter.cfg
+++ b/counter.cfg
@@ -1,26 +1,34 @@
 # ARTS Framework Counter Configuration
 # =====================================
 # 
-# Format: COUNTER_NAME=captureMode[,captureLevel]
+# Format: COUNTER_NAME=counterMode[,counterLevel[,reduceMethod]]
 #
-# captureMode (required when enabling a counter):
+# counterMode (required when enabling a counter):
 #   OFF      - Counter disabled
 #   ONCE     - Single value captured at the end (no periodic capture)
 #   PERIODIC - Periodic capture during execution
 #
-# captureLevel (optional, default: NODE):
+# counterLevel (optional, default: NODE):
 #   THREAD   - Per-thread output (no reduction across threads)
 #   NODE     - Per-node output (reduce values across threads)
 #   CLUSTER  - Per-cluster output (reduce values across all nodes)
 #
+# reduceMethod (optional, default: SUM):
+#   SUM      - Sum values across threads/nodes
+#   MAX      - Maximum value across threads/nodes
+#   MIN      - Minimum value across threads/nodes
+#   MASTER   - Use master thread/node's value only (no reduction)
+#
 # Examples:
-#   edtRunningTime=OFF              # Disabled
-#   edtRunningTime=ONCE             # Single value at end, NODE level (default)
-#   edtRunningTime=ONCE,NODE        # Single value at end, NODE level (explicit)
-#   edtRunningTime=ONCE,THREAD      # Single value at end, per-thread output
-#   edtRunningTime=PERIODIC         # Periodic capture, NODE level (default)
-#   edtRunningTime=PERIODIC,THREAD  # Periodic capture, per-thread output
-#   edtRunningTime=PERIODIC,NODE    # Periodic capture, per-node output
+#   edtRunningTime=OFF                     # Disabled
+#   edtRunningTime=ONCE                    # Single value at end, NODE level, SUM reduce (defaults)
+#   edtRunningTime=ONCE,NODE               # Single value at end, NODE level, SUM reduce
+#   edtRunningTime=ONCE,THREAD             # Single value at end, per-thread output
+#   edtRunningTime=PERIODIC                # Periodic capture, NODE level, SUM reduce (defaults)
+#   edtRunningTime=PERIODIC,THREAD         # Periodic capture, per-thread output
+#   edtRunningTime=PERIODIC,NODE,MAX       # Periodic capture, per-node output, MAX reduce
+#   edtRunningTime=PERIODIC,CLUSTER,SUM    # Periodic capture, cluster-wide, SUM reduce
+#   initializationTime=ONCE,CLUSTER,MASTER # Single value, cluster level, master node only
 #
 # Edit this file to configure counters, then re-run: cmake
 
@@ -29,20 +37,20 @@
 # =============================================================================
 
 # EDT (Event-Driven Task) Counters
-edtRunningTime=OFF
-numEdtsCreated=OFF
-numEdtsAcquired=OFF
-numEdtsFinished=OFF
+edtRunningTime=PERIODIC,CLUSTER
+numEdtsCreated=PERIODIC,CLUSTER
+numEdtsAcquired=PERIODIC,CLUSTER
+numEdtsFinished=PERIODIC,CLUSTER
 
 # DB (Data Block) Counters
-numDbsCreated=OFF
+numDbsCreated=PERIODIC,CLUSTER
 
 # Memory Counters
-memoryFootprint=OFF
+memoryFootprint=PERIODIC,CLUSTER
 
 # Remote Counters
-remoteBytesSent=OFF
-remoteBytesReceived=OFF
+remoteBytesSent=PERIODIC,CLUSTER
+remoteBytesReceived=PERIODIC,CLUSTER
 
 # =============================================================================
 # Twin-Diff Optimization Counters
@@ -73,10 +81,9 @@ artsIdEdtCaptures=OFF            # Per-arts_id EDT detailed captures (ArrayList)
 artsIdDbCaptures=OFF             # Per-arts_id DB detailed captures (ArrayList)
 
 # =============================================================================
-# Per-Node Timing Counters
+# Per-Node Timing Counters (CLUSTER level only)
 # =============================================================================
 # Track high-level timing for the ARTS runtime phases
-# These are captured once at the end and aggregated at NODE level
-initializationTime=ONCE,NODE     # Time spent in ARTS initialization phase
-endToEndTime=ONCE,NODE           # Total end-to-end execution time
-finalizationTime=ONCE,NODE       # Time spent in ARTS finalization/shutdown phase
+# These are restricted to CLUSTER level and use master node measurements only
+initializationTime=ONCE,CLUSTER,MASTER  # Time spent in ARTS initialization phase
+endToEndTime=ONCE,CLUSTER,MASTER        # Total end-to-end execution time

--- a/counter.cfg
+++ b/counter.cfg
@@ -1,10 +1,27 @@
 # ARTS Framework Counter Configuration
-# Format: COUNTER_NAME=MODE
-# MODE can be: OFF, ONCE, THREAD, or NODE
-#   OFF    - Counter disabled
-#   ONCE   - Print counter values at the end (single output)
-#   THREAD - Capture each thread's counters without reduction (per-thread output)
-#   NODE   - Capture and reduce counters per node (per-node output)
+# =====================================
+# 
+# Format: COUNTER_NAME=captureMode[,captureLevel]
+#
+# captureMode (required):
+#   OFF      - Counter disabled
+#   ONCE     - Single value captured at the end (no periodic capture)
+#   PERIODIC - Periodic capture during execution
+#
+# captureLevel (optional, default: NODE):
+#   THREAD   - Per-thread output (no reduction across threads)
+#   NODE     - Per-node output (reduce values across threads)
+#   # CLUSTER - Per-cluster output (not implemented)
+#
+# Examples:
+#   edtRunningTime=OFF              # Disabled
+#   edtRunningTime=ONCE             # Single value at end, NODE level (default)
+#   edtRunningTime=ONCE,NODE        # Single value at end, NODE level (explicit)
+#   edtRunningTime=ONCE,THREAD      # Single value at end, per-thread output
+#   edtRunningTime=PERIODIC         # Periodic capture, NODE level (default)
+#   edtRunningTime=PERIODIC,THREAD  # Periodic capture, per-thread output
+#   edtRunningTime=PERIODIC,NODE    # Periodic capture, per-node output
+#
 # Edit this file to configure counters, then re-run: cmake
 
 # =============================================================================
@@ -50,7 +67,16 @@ ownerUpdatesPerformed=OFF        # Count of owner updates performed
 # =============================================================================
 # Track performance metrics per arts_id (compiler-assigned unique identifier)
 # This enables linking compile-time metadata with runtime performance data
-artsIdEdtMetrics=THREAD          # Per-arts_id EDT aggregate metrics (hash table)
-artsIdDbMetrics=THREAD           # Per-arts_id DB aggregate metrics (hash table)
+artsIdEdtMetrics=OFF             # Per-arts_id EDT aggregate metrics (hash table)
+artsIdDbMetrics=OFF              # Per-arts_id DB aggregate metrics (hash table)
 artsIdEdtCaptures=OFF            # Per-arts_id EDT detailed captures (ArrayList)
 artsIdDbCaptures=OFF             # Per-arts_id DB detailed captures (ArrayList)
+
+# =============================================================================
+# Per-Node Timing Counters
+# =============================================================================
+# Track high-level timing for the ARTS runtime phases
+# These are captured once at the end and aggregated at NODE level
+initializationTime=ONCE,NODE     # Time spent in ARTS initialization phase
+endToEndTime=ONCE,NODE           # Total end-to-end execution time
+finalizationTime=ONCE,NODE       # Time spent in ARTS finalization/shutdown phase

--- a/counter.cfg
+++ b/counter.cfg
@@ -3,7 +3,7 @@
 # 
 # Format: COUNTER_NAME=captureMode[,captureLevel]
 #
-# captureMode (required):
+# captureMode (required when enabling a counter):
 #   OFF      - Counter disabled
 #   ONCE     - Single value captured at the end (no periodic capture)
 #   PERIODIC - Periodic capture during execution

--- a/counter.cfg
+++ b/counter.cfg
@@ -11,7 +11,7 @@
 # captureLevel (optional, default: NODE):
 #   THREAD   - Per-thread output (no reduction across threads)
 #   NODE     - Per-node output (reduce values across threads)
-#   # CLUSTER - Per-cluster output (not implemented)
+#   CLUSTER  - Per-cluster output (reduce values across all nodes)
 #
 # Examples:
 #   edtRunningTime=OFF              # Disabled

--- a/counter.cluster-test.cfg
+++ b/counter.cluster-test.cfg
@@ -7,7 +7,7 @@ numEdtsFinished=ONCE,CLUSTER
 # DB counters
 numDbsCreated=OFF
 
-# Memory Counters  
+# Memory Counters
 memoryFootprint=OFF
 
 # Remote Counters

--- a/counter.cluster-test.cfg
+++ b/counter.cluster-test.cfg
@@ -1,0 +1,32 @@
+# Test configuration for CLUSTER level counters
+# EDT counters with different levels
+edtRunningTime=ONCE,CLUSTER
+numEdtsCreated=ONCE,NODE
+numEdtsFinished=ONCE,CLUSTER
+
+# DB counters
+numDbsCreated=OFF
+
+# Memory Counters  
+memoryFootprint=OFF
+
+# Remote Counters
+remoteBytesSent=ONCE,CLUSTER
+remoteBytesReceived=ONCE,CLUSTER
+
+# All other counters off
+twinDiffSaves=OFF
+twinDiffUpdates=OFF
+twinDiffBytesWritten=OFF
+twinDiffBytesSkipped=OFF
+dbBytesWritten=OFF
+dbBytesRead=OFF
+dbLocalAccesses=OFF
+dbRemoteAccesses=OFF
+dbCacheMisses=OFF
+routeTableEntries=OFF
+epochCount=OFF
+artsIdEdtMetrics=OFF
+artsIdDbMetrics=OFF
+artsIdEdtCaptures=OFF
+artsIdDbCaptures=OFF

--- a/test/testArtsId.c
+++ b/test/testArtsId.c
@@ -10,8 +10,8 @@
 #include "arts/arts.h"
 #include "arts/introspection/ArtsIdCounter.h"
 #include "arts/introspection/Counter.h"
-#include "arts/system/ArtsPrint.h"
 #include "arts/runtime/Globals.h"
+#include "arts/system/ArtsPrint.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -27,318 +27,331 @@ volatile unsigned int *testResult = NULL;
 /// Test EDT that simulates work
 void testEdtWorker(uint32_t paramc, uint64_t *paramv, uint32_t depc,
                    artsEdtDep_t depv[]) {
-    ARTS_PRINT("[testEdtWorker] Entry - paramc=%u, depc=%u", paramc, depc);
+  ARTS_PRINT("[testEdtWorker] Entry - paramc=%u, depc=%u", paramc, depc);
 
-    if (paramc < 1) {
-        ARTS_ERROR("[testEdtWorker] Missing arts_id parameter");
-        return;
+  if (paramc < 1) {
+    ARTS_ERROR("[testEdtWorker] Missing arts_id parameter");
+    return;
+  }
+
+  uint64_t expected_arts_id = paramv[0];
+  unsigned int nodeId = artsGetCurrentNode();
+
+  ARTS_PRINT("Node %u - EDT with expected arts_id=%lu executing", nodeId,
+             expected_arts_id);
+
+  // Simulate some work (matrix computation)
+  if (depc > 0 && depv[0].ptr != NULL) {
+    double *matrix = (double *)depv[0].ptr;
+    unsigned int size = 32; // Small test matrix
+
+    // Simple matrix operation to simulate work
+    for (unsigned int i = 0; i < size; i++) {
+      for (unsigned int j = 0; j < size; j++) {
+        matrix[i * size + j] = (double)(i * j + expected_arts_id);
+      }
     }
 
-    uint64_t expected_arts_id = paramv[0];
-    unsigned int nodeId = artsGetCurrentNode();
+    ARTS_PRINT("Node %u - EDT %lu completed matrix computation", nodeId,
+               expected_arts_id);
+  }
 
-    ARTS_PRINT("Node %u - EDT with expected arts_id=%lu executing",
-               nodeId, expected_arts_id);
-
-    // Simulate some work (matrix computation)
-    if (depc > 0 && depv[0].ptr != NULL) {
-        double *matrix = (double *)depv[0].ptr;
-        unsigned int size = 32;  // Small test matrix
-
-        // Simple matrix operation to simulate work
-        for (unsigned int i = 0; i < size; i++) {
-            for (unsigned int j = 0; j < size; j++) {
-                matrix[i * size + j] = (double)(i * j + expected_arts_id);
-            }
-        }
-
-        ARTS_PRINT("Node %u - EDT %lu completed matrix computation",
-                   nodeId, expected_arts_id);
-    }
-
-    ARTS_PRINT("[testEdtWorker] Completed - arts_id=%lu", expected_arts_id);
+  ARTS_PRINT("[testEdtWorker] Completed - arts_id=%lu", expected_arts_id);
 }
 
 /// Test EDT that reads multiple DBs
 void testEdtReader(uint32_t paramc, uint64_t *paramv, uint32_t depc,
                    artsEdtDep_t depv[]) {
-    ARTS_PRINT("[testEdtReader] Entry - paramc=%u, depc=%u", paramc, depc);
+  ARTS_PRINT("[testEdtReader] Entry - paramc=%u, depc=%u", paramc, depc);
 
-    if (paramc < 1) {
-        ARTS_ERROR("[testEdtReader] Missing arts_id parameter");
-        return;
+  if (paramc < 1) {
+    ARTS_ERROR("[testEdtReader] Missing arts_id parameter");
+    return;
+  }
+
+  uint64_t expected_arts_id = paramv[0];
+  unsigned int nodeId = artsGetCurrentNode();
+
+  ARTS_PRINT("Node %u - Reader EDT %lu accessing %u DBs", nodeId,
+             expected_arts_id, depc);
+
+  // Access multiple DBs
+  for (uint32_t i = 0; i < depc; i++) {
+    if (depv[i].ptr != NULL) {
+      double *matrix = (double *)depv[i].ptr;
+      double sum = 0.0;
+      unsigned int size = 32;
+
+      // Read and sum matrix
+      for (unsigned int j = 0; j < size * size; j++) {
+        sum += matrix[j];
+      }
+
+      ARTS_PRINT("Node %u - Reader EDT %lu: DB[%u] sum=%.2f", nodeId,
+                 expected_arts_id, i, sum);
     }
+  }
 
-    uint64_t expected_arts_id = paramv[0];
-    unsigned int nodeId = artsGetCurrentNode();
-
-    ARTS_PRINT("Node %u - Reader EDT %lu accessing %u DBs",
-               nodeId, expected_arts_id, depc);
-
-    // Access multiple DBs
-    for (uint32_t i = 0; i < depc; i++) {
-        if (depv[i].ptr != NULL) {
-            double *matrix = (double *)depv[i].ptr;
-            double sum = 0.0;
-            unsigned int size = 32;
-
-            // Read and sum matrix
-            for (unsigned int j = 0; j < size * size; j++) {
-                sum += matrix[j];
-            }
-
-            ARTS_PRINT("Node %u - Reader EDT %lu: DB[%u] sum=%.2f",
-                       nodeId, expected_arts_id, i, sum);
-        }
-    }
-
-    ARTS_PRINT("[testEdtReader] Completed - arts_id=%lu", expected_arts_id);
+  ARTS_PRINT("[testEdtReader] Completed - arts_id=%lu", expected_arts_id);
 }
 
 /// Validator EDT: Checks arts_id values in created structures
 void validator(uint32_t paramc, uint64_t *paramv, uint32_t depc,
                artsEdtDep_t depv[]) {
-    ARTS_PRINT("[Validator] Starting validation");
+  ARTS_PRINT("[Validator] Starting validation");
 
-    bool success = true;
-    unsigned int errors = 0;
+  bool success = true;
+  unsigned int errors = 0;
 
-    // Test 1: Verify arts_id tracking data structures exist
-    ARTS_PRINT("[Validator] Test 1: Checking arts_id data structures...");
+  // Test 1: Verify arts_id tracking data structures exist
+  ARTS_PRINT("[Validator] Test 1: Checking arts_id data structures...");
 
 #if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
-    ARTS_PRINT("[Validator] ✓ arts_id hash table enabled");
+  ARTS_PRINT("[Validator] ✓ arts_id hash table enabled");
 #else
-    ARTS_PRINT("[Validator] ✗ arts_id hash table disabled (expected if counters OFF)");
+  ARTS_PRINT(
+      "[Validator] ✗ arts_id hash table disabled (expected if counters OFF)");
 #endif
 
 #if ENABLE_artsIdEdtCaptures
-    ARTS_PRINT("[Validator] ✓ EDT captures enabled");
+  ARTS_PRINT("[Validator] ✓ EDT captures enabled");
 #else
-    ARTS_PRINT("[Validator] ✗ EDT captures disabled (expected if counters OFF)");
+  ARTS_PRINT("[Validator] ✗ EDT captures disabled (expected if counters OFF)");
 #endif
 
 #if ENABLE_artsIdDbCaptures
-    ARTS_PRINT("[Validator] ✓ DB captures enabled");
+  ARTS_PRINT("[Validator] ✓ DB captures enabled");
 #else
-    ARTS_PRINT("[Validator] ✗ DB captures disabled (expected if counters OFF)");
+  ARTS_PRINT("[Validator] ✗ DB captures disabled (expected if counters OFF)");
 #endif
 
-    // Test 2: Verify counter mode configuration
-    ARTS_PRINT("[Validator] Test 2: Checking counter modes...");
-    extern const unsigned int artsCounterMode[];
+  // Test 2: Verify counter mode configuration
+  ARTS_PRINT("[Validator] Test 2: Checking counter modes...");
 
-    unsigned int edt_metrics_mode = artsCounterMode[artsIdEdtMetrics];
-    unsigned int db_metrics_mode = artsCounterMode[artsIdDbMetrics];
-    unsigned int edt_captures_mode = artsCounterMode[artsIdEdtCaptures];
-    unsigned int db_captures_mode = artsCounterMode[artsIdDbCaptures];
+  unsigned int edt_metrics_mode = artsCaptureModeArray[artsIdEdtMetrics];
+  unsigned int db_metrics_mode = artsCaptureModeArray[artsIdDbMetrics];
+  unsigned int edt_captures_mode = artsCaptureModeArray[artsIdEdtCaptures];
+  unsigned int db_captures_mode = artsCaptureModeArray[artsIdDbCaptures];
 
-    ARTS_PRINT("[Validator] artsIdEdtMetrics mode: %u (0=OFF, 1=ONCE, 2=THREAD, 3=NODE)",
-               edt_metrics_mode);
-    ARTS_PRINT("[Validator] artsIdDbMetrics mode: %u", db_metrics_mode);
-    ARTS_PRINT("[Validator] artsIdEdtCaptures mode: %u", edt_captures_mode);
-    ARTS_PRINT("[Validator] artsIdDbCaptures mode: %u", db_captures_mode);
+  ARTS_PRINT(
+      "[Validator] artsIdEdtMetrics mode: %u (0=OFF, 1=ONCE, 2=PERIODIC)",
+      edt_metrics_mode);
+  ARTS_PRINT("[Validator] artsIdDbMetrics mode: %u", db_metrics_mode);
+  ARTS_PRINT("[Validator] artsIdEdtCaptures mode: %u", edt_captures_mode);
+  ARTS_PRINT("[Validator] artsIdDbCaptures mode: %u", db_captures_mode);
 
-    // Test 3: Per-thread JSON export
-    ARTS_PRINT("[Validator] Test 3: Per-thread JSON export...");
+  // Test 3: Per-thread JSON export
+  ARTS_PRINT("[Validator] Test 3: Per-thread JSON export...");
 
 #if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
-    ARTS_PRINT("[Validator] ✓ Per-thread export happens during thread cleanup");
-    ARTS_PRINT("[Validator] ✓ Look for counters_thread_N.json files after shutdown");
+  ARTS_PRINT("[Validator] ✓ Per-thread export happens during thread cleanup");
+  ARTS_PRINT(
+      "[Validator] ✓ Look for counters_thread_N.json files after shutdown");
 #else
-    ARTS_PRINT("[Validator] ⚠ Export skipped (counters disabled)");
+  ARTS_PRINT("[Validator] ⚠ Export skipped (counters disabled)");
 #endif
 
-    // Test 4: Verify hash table statistics (if enabled)
+  // Test 4: Verify hash table statistics (if enabled)
 #if ENABLE_artsIdEdtMetrics || ENABLE_artsIdDbMetrics
-    ARTS_PRINT("[Validator] Test 4: Checking hash table statistics...");
+  ARTS_PRINT("[Validator] Test 4: Checking hash table statistics...");
 
-    // Access thread info (this is thread 0, the main worker)
-    unsigned int total_edt_collisions = 0;
-    unsigned int total_db_collisions = 0;
+  // Access thread info (this is thread 0, the main worker)
+  unsigned int total_edt_collisions = 0;
+  unsigned int total_db_collisions = 0;
 
-    for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
-        // Note: We can't easily access per-thread data from validator EDT
-        // This is just to demonstrate the concept
-        ARTS_PRINT("[Validator] Thread %u data collection (implementation pending)", t);
-    }
+  for (unsigned int t = 0; t < artsNodeInfo.totalThreadCount; t++) {
+    // Note: We can't easily access per-thread data from validator EDT
+    // This is just to demonstrate the concept
+    ARTS_PRINT("[Validator] Thread %u data collection (implementation pending)",
+               t);
+  }
 
-    ARTS_PRINT("[Validator] Total EDT hash collisions: %u", total_edt_collisions);
-    ARTS_PRINT("[Validator] Total DB hash collisions: %u", total_db_collisions);
+  ARTS_PRINT("[Validator] Total EDT hash collisions: %u", total_edt_collisions);
+  ARTS_PRINT("[Validator] Total DB hash collisions: %u", total_db_collisions);
 #endif
 
-    // Final result
-    if (success) {
-        ARTS_PRINT("═══════════════════════════════════════");
-        ARTS_PRINT("TEST STATUS: SUCCESS");
-        ARTS_PRINT("═══════════════════════════════════════");
-        ARTS_PRINT("✓ All arts_id tracking tests passed!");
-        ARTS_PRINT("✓ Created %u EDTs with arts_id values", NUM_TEST_EDTS);
-        ARTS_PRINT("✓ Created %u DBs with arts_id values", NUM_TEST_DBS);
-        ARTS_PRINT("✓ Counter infrastructure validated");
-        if (testResult)
-            *testResult = 1;
-    } else {
-        ARTS_PRINT("═══════════════════════════════════════");
-        ARTS_PRINT("TEST STATUS: FAILURE");
-        ARTS_PRINT("═══════════════════════════════════════");
-        ARTS_PRINT("✗ Found %u errors in arts_id tracking!", errors);
-        if (testResult)
-            *testResult = 0;
-    }
+  // Final result
+  if (success) {
+    ARTS_PRINT("═══════════════════════════════════════");
+    ARTS_PRINT("TEST STATUS: SUCCESS");
+    ARTS_PRINT("═══════════════════════════════════════");
+    ARTS_PRINT("✓ All arts_id tracking tests passed!");
+    ARTS_PRINT("✓ Created %u EDTs with arts_id values", NUM_TEST_EDTS);
+    ARTS_PRINT("✓ Created %u DBs with arts_id values", NUM_TEST_DBS);
+    ARTS_PRINT("✓ Counter infrastructure validated");
+    if (testResult)
+      *testResult = 1;
+  } else {
+    ARTS_PRINT("═══════════════════════════════════════");
+    ARTS_PRINT("TEST STATUS: FAILURE");
+    ARTS_PRINT("═══════════════════════════════════════");
+    ARTS_PRINT("✗ Found %u errors in arts_id tracking!", errors);
+    if (testResult)
+      *testResult = 0;
+  }
 }
 
 void artsMain(int argc, char **argv) {
-    ARTS_PRINT("═══════════════════════════════════════");
-    ARTS_PRINT("ARTS arts_id Tracking Test");
-    ARTS_PRINT("═══════════════════════════════════════");
-    ARTS_PRINT("Test Configuration:");
-    ARTS_PRINT("- Test EDTs: %u", NUM_TEST_EDTS);
-    ARTS_PRINT("- Test DBs:  %u", NUM_TEST_DBS);
-    ARTS_PRINT("- Nodes:     %u", artsGetTotalNodes());
-    ARTS_PRINT("- Threads:   %u", artsNodeInfo.totalThreadCount);
-    ARTS_PRINT("═══════════════════════════════════════\n");
+  ARTS_PRINT("═══════════════════════════════════════");
+  ARTS_PRINT("ARTS arts_id Tracking Test");
+  ARTS_PRINT("═══════════════════════════════════════");
+  ARTS_PRINT("Test Configuration:");
+  ARTS_PRINT("- Test EDTs: %u", NUM_TEST_EDTS);
+  ARTS_PRINT("- Test DBs:  %u", NUM_TEST_DBS);
+  ARTS_PRINT("- Nodes:     %u", artsGetTotalNodes());
+  ARTS_PRINT("- Threads:   %u", artsNodeInfo.totalThreadCount);
+  ARTS_PRINT("═══════════════════════════════════════\n");
 
-    // Allocate test result flag
-    testResult = (volatile unsigned int *)artsMalloc(sizeof(unsigned int));
-    *testResult = 0;
+  // Allocate test result flag
+  testResult = (volatile unsigned int *)artsMalloc(sizeof(unsigned int));
+  *testResult = 0;
 
-    // Start epoch for coordination
-    artsGuid_t epochGuid = artsInitializeAndStartEpoch(NULL_GUID, 0);
-    ARTS_PRINT("[Step 1] Started epoch (guid: %lu)\n", epochGuid);
+  // Start epoch for coordination
+  artsGuid_t epochGuid = artsInitializeAndStartEpoch(NULL_GUID, 0);
+  ARTS_PRINT("[Step 1] Started epoch (guid: %lu)\n", epochGuid);
 
-    // Create test DBs with arts_id values
-    ARTS_PRINT("[Step 3] Creating %u test DBs with arts_id values:", NUM_TEST_DBS);
-    artsGuid_t *dbGuids = (artsGuid_t *)artsMalloc(NUM_TEST_DBS * sizeof(artsGuid_t));
-    void **dbPtrs = (void **)artsMalloc(NUM_TEST_DBS * sizeof(void *));
+  // Create test DBs with arts_id values
+  ARTS_PRINT("[Step 3] Creating %u test DBs with arts_id values:",
+             NUM_TEST_DBS);
+  artsGuid_t *dbGuids =
+      (artsGuid_t *)artsMalloc(NUM_TEST_DBS * sizeof(artsGuid_t));
+  void **dbPtrs = (void **)artsMalloc(NUM_TEST_DBS * sizeof(void *));
 
-    unsigned int matrixSize = 32 * 32 * sizeof(double);
+  unsigned int matrixSize = 32 * 32 * sizeof(double);
 
-    for (unsigned int i = 0; i < NUM_TEST_DBS; i++) {
-        uint64_t arts_id = TEST_ARTS_ID_BASE + 100 + i;  // DB arts_id: 1100, 1101, ...
+  for (unsigned int i = 0; i < NUM_TEST_DBS; i++) {
+    uint64_t arts_id =
+        TEST_ARTS_ID_BASE + 100 + i; // DB arts_id: 1100, 1101, ...
 
-        dbGuids[i] = artsDbCreateWithArtsId(&dbPtrs[i], matrixSize,
-                                            ARTS_DB_WRITE, arts_id);
+    dbGuids[i] =
+        artsDbCreateWithArtsId(&dbPtrs[i], matrixSize, ARTS_DB_WRITE, arts_id);
 
-        // Initialize matrix to zeros
-        double *matrix = (double *)dbPtrs[i];
-        for (unsigned int j = 0; j < 32 * 32; j++) {
-            matrix[j] = 0.0;
-        }
-
-        ARTS_PRINT("  - DB[%u]: guid=%lu, arts_id=%lu, size=%u bytes",
-                   i, dbGuids[i], arts_id, matrixSize);
+    // Initialize matrix to zeros
+    double *matrix = (double *)dbPtrs[i];
+    for (unsigned int j = 0; j < 32 * 32; j++) {
+      matrix[j] = 0.0;
     }
 
-    ARTS_PRINT("");
+    ARTS_PRINT("  - DB[%u]: guid=%lu, arts_id=%lu, size=%u bytes", i,
+               dbGuids[i], arts_id, matrixSize);
+  }
 
-    // Create validator EDT first
-    ARTS_PRINT("[Step 4] Creating validator EDT (will run last)...");
-    artsGuid_t validatorGuid =
-        artsEdtCreateWithEpoch(validator, 0, 0, NULL, 1, epochGuid);
+  ARTS_PRINT("");
 
-    // Create writer EDTs with arts_id values
-    ARTS_PRINT("[Step 5] Creating %u writer EDTs with arts_id values:", NUM_TEST_EDTS);
-    artsGuid_t *writerGuids = (artsGuid_t *)artsMalloc(NUM_TEST_EDTS * sizeof(artsGuid_t));
-    unsigned int *writerDbIndices = (unsigned int *)artsMalloc(NUM_TEST_EDTS * sizeof(unsigned int));
+  // Create validator EDT first
+  ARTS_PRINT("[Step 4] Creating validator EDT (will run last)...");
+  artsGuid_t validatorGuid =
+      artsEdtCreateWithEpoch(validator, 0, 0, NULL, 1, epochGuid);
 
-    for (unsigned int i = 0; i < NUM_TEST_EDTS; i++) {
-        uint64_t arts_id = TEST_ARTS_ID_BASE + i;  // EDT arts_id: 1000, 1001, ...
-        uint64_t param = arts_id;
+  // Create writer EDTs with arts_id values
+  ARTS_PRINT("[Step 5] Creating %u writer EDTs with arts_id values:",
+             NUM_TEST_EDTS);
+  artsGuid_t *writerGuids =
+      (artsGuid_t *)artsMalloc(NUM_TEST_EDTS * sizeof(artsGuid_t));
+  unsigned int *writerDbIndices =
+      (unsigned int *)artsMalloc(NUM_TEST_EDTS * sizeof(unsigned int));
 
-        // Distribute EDTs across nodes (round-robin)
-        unsigned int targetNode = i % artsGetTotalNodes();
+  for (unsigned int i = 0; i < NUM_TEST_EDTS; i++) {
+    uint64_t arts_id = TEST_ARTS_ID_BASE + i; // EDT arts_id: 1000, 1001, ...
+    uint64_t param = arts_id;
 
-        // Each EDT will use one DB
-        unsigned int dbIndex = i % NUM_TEST_DBS;
-        writerDbIndices[i] = dbIndex;
+    // Distribute EDTs across nodes (round-robin)
+    unsigned int targetNode = i % artsGetTotalNodes();
 
-        writerGuids[i] = artsEdtCreateWithArtsId(
-            testEdtWorker, targetNode, 1, &param, 1, arts_id);
+    // Each EDT will use one DB
+    unsigned int dbIndex = i % NUM_TEST_DBS;
+    writerDbIndices[i] = dbIndex;
 
-        ARTS_PRINT("  - EDT[%u]: guid=%lu, arts_id=%lu, node=%u, using DB[%u]",
-                   i, writerGuids[i], arts_id, targetNode, dbIndex);
+    writerGuids[i] = artsEdtCreateWithArtsId(testEdtWorker, targetNode, 1,
+                                             &param, 1, arts_id);
+
+    ARTS_PRINT("  - EDT[%u]: guid=%lu, arts_id=%lu, node=%u, using DB[%u]", i,
+               writerGuids[i], arts_id, targetNode, dbIndex);
+  }
+
+  ARTS_PRINT("");
+
+  // Create reader EDTs with arts_id values
+  ARTS_PRINT("[Step 6] Creating reader EDTs with arts_id values:");
+
+  unsigned int numReaders = 3;
+  artsGuid_t *readerGuids =
+      (artsGuid_t *)artsMalloc(numReaders * sizeof(artsGuid_t));
+  unsigned int *readerNumDeps =
+      (unsigned int *)artsMalloc(numReaders * sizeof(unsigned int));
+
+  for (unsigned int i = 0; i < numReaders; i++) {
+    uint64_t arts_id =
+        TEST_ARTS_ID_BASE + 200 + i; // Reader arts_id: 1200, 1201, ...
+    uint64_t param = arts_id;
+
+    unsigned int targetNode = i % artsGetTotalNodes();
+
+    // Readers will depend on multiple DBs
+    unsigned int numDeps =
+        (i % NUM_TEST_DBS) + 1; // 1 to NUM_TEST_DBS dependencies
+    readerNumDeps[i] = numDeps;
+
+    readerGuids[i] = artsEdtCreateWithArtsId(testEdtReader, targetNode, 1,
+                                             &param, numDeps, arts_id);
+
+    ARTS_PRINT("  - Reader[%u]: guid=%lu, arts_id=%lu, node=%u, deps=%u", i,
+               readerGuids[i], arts_id, targetNode, numDeps);
+  }
+
+  ARTS_PRINT("");
+
+  // Record all dependencies using artsRecordDep (like testTwinDiff)
+  ARTS_PRINT("[Step 7] Recording dependencies for all EDTs...");
+
+  // Record writer dependencies
+  for (unsigned int i = 0; i < NUM_TEST_EDTS; i++) {
+    unsigned int dbIndex = writerDbIndices[i];
+    artsRecordDep(dbGuids[dbIndex], writerGuids[i], 0, ARTS_DB_WRITE, true);
+  }
+
+  // Record reader dependencies
+  for (unsigned int i = 0; i < numReaders; i++) {
+    unsigned int numDeps = readerNumDeps[i];
+    for (unsigned int d = 0; d < numDeps; d++) {
+      artsRecordDep(dbGuids[d], readerGuids[i], d, ARTS_DB_READ, true);
     }
+  }
 
-    ARTS_PRINT("");
+  // Record validator dependency (reads DB[0] after all writers complete)
+  artsRecordDep(dbGuids[0], validatorGuid, 0, ARTS_DB_READ, false);
 
-    // Create reader EDTs with arts_id values
-    ARTS_PRINT("[Step 6] Creating reader EDTs with arts_id values:");
+  ARTS_PRINT("[Step 8] Waiting for epoch to complete...");
 
-    unsigned int numReaders = 3;
-    artsGuid_t *readerGuids = (artsGuid_t *)artsMalloc(numReaders * sizeof(artsGuid_t));
-    unsigned int *readerNumDeps = (unsigned int *)artsMalloc(numReaders * sizeof(unsigned int));
+  // Wait for all EDTs to complete
+  artsWaitOnHandle(epochGuid);
 
-    for (unsigned int i = 0; i < numReaders; i++) {
-        uint64_t arts_id = TEST_ARTS_ID_BASE + 200 + i;  // Reader arts_id: 1200, 1201, ...
-        uint64_t param = arts_id;
+  ARTS_PRINT("[Step 9] Epoch completed\n");
 
-        unsigned int targetNode = i % artsGetTotalNodes();
+  // Check test result
+  if (*testResult == 1) {
+    ARTS_PRINT("Overall test result: PASSED");
+  } else {
+    ARTS_PRINT("Overall test result: FAILED or INCOMPLETE");
+  }
 
-        // Readers will depend on multiple DBs
-        unsigned int numDeps = (i % NUM_TEST_DBS) + 1;  // 1 to NUM_TEST_DBS dependencies
-        readerNumDeps[i] = numDeps;
+  // Note: Counter export now happens automatically via counter infrastructure
+  // No manual export call needed - artsCounterWriteThread() handles all metrics
 
-        readerGuids[i] = artsEdtCreateWithArtsId(
-            testEdtReader, targetNode, 1, &param, numDeps, arts_id);
+  // Cleanup
+  artsFree((void *)writerGuids);
+  artsFree((void *)writerDbIndices);
+  artsFree((void *)readerGuids);
+  artsFree((void *)readerNumDeps);
+  artsFree((void *)dbPtrs);
+  artsFree((void *)dbGuids);
+  artsFree((void *)testResult);
 
-        ARTS_PRINT("  - Reader[%u]: guid=%lu, arts_id=%lu, node=%u, deps=%u",
-                   i, readerGuids[i], arts_id, targetNode, numDeps);
-    }
-
-    ARTS_PRINT("");
-
-    // Record all dependencies using artsRecordDep (like testTwinDiff)
-    ARTS_PRINT("[Step 7] Recording dependencies for all EDTs...");
-
-    // Record writer dependencies
-    for (unsigned int i = 0; i < NUM_TEST_EDTS; i++) {
-        unsigned int dbIndex = writerDbIndices[i];
-        artsRecordDep(dbGuids[dbIndex], writerGuids[i], 0, ARTS_DB_WRITE, true);
-    }
-
-    // Record reader dependencies
-    for (unsigned int i = 0; i < numReaders; i++) {
-        unsigned int numDeps = readerNumDeps[i];
-        for (unsigned int d = 0; d < numDeps; d++) {
-            artsRecordDep(dbGuids[d], readerGuids[i], d, ARTS_DB_READ, true);
-        }
-    }
-
-    // Record validator dependency (reads DB[0] after all writers complete)
-    artsRecordDep(dbGuids[0], validatorGuid, 0, ARTS_DB_READ, false);
-
-    ARTS_PRINT("[Step 8] Waiting for epoch to complete...");
-
-    // Wait for all EDTs to complete
-    artsWaitOnHandle(epochGuid);
-
-    ARTS_PRINT("[Step 9] Epoch completed\n");
-
-    // Check test result
-    if (*testResult == 1) {
-        ARTS_PRINT("Overall test result: PASSED");
-    } else {
-        ARTS_PRINT("Overall test result: FAILED or INCOMPLETE");
-    }
-
-    // Note: Counter export now happens automatically via counter infrastructure
-    // No manual export call needed - artsCounterWriteThread() handles all metrics
-
-    // Cleanup
-    artsFree((void *)writerGuids);
-    artsFree((void *)writerDbIndices);
-    artsFree((void *)readerGuids);
-    artsFree((void *)readerNumDeps);
-    artsFree((void *)dbPtrs);
-    artsFree((void *)dbGuids);
-    artsFree((void *)testResult);
-
-    // Shutdown
-    artsShutdown();
+  // Shutdown
+  artsShutdown();
 }
 
 int main(int argc, char **argv) {
-    int ret = artsRT(argc, argv);
-    return ret;
+  int ret = artsRT(argc, argv);
+  return ret;
 }

--- a/test/testArtsId.c
+++ b/test/testArtsId.c
@@ -128,10 +128,10 @@ void validator(uint32_t paramc, uint64_t *paramv, uint32_t depc,
   // Test 2: Verify counter mode configuration
   ARTS_PRINT("[Validator] Test 2: Checking counter modes...");
 
-  unsigned int edt_metrics_mode = artsCaptureModeArray[artsIdEdtMetrics];
-  unsigned int db_metrics_mode = artsCaptureModeArray[artsIdDbMetrics];
-  unsigned int edt_captures_mode = artsCaptureModeArray[artsIdEdtCaptures];
-  unsigned int db_captures_mode = artsCaptureModeArray[artsIdDbCaptures];
+  unsigned int edt_metrics_mode = artsCounterModeArray[artsIdEdtMetrics];
+  unsigned int db_metrics_mode = artsCounterModeArray[artsIdDbMetrics];
+  unsigned int edt_captures_mode = artsCounterModeArray[artsIdEdtCaptures];
+  unsigned int db_captures_mode = artsCounterModeArray[artsIdDbCaptures];
 
   ARTS_PRINT(
       "[Validator] artsIdEdtMetrics mode: %u (0=OFF, 1=ONCE, 2=PERIODIC)",


### PR DESCRIPTION
This pull request makes major improvements to the counter introspection and configuration system, focusing on flexibility, maintainability, and clarity. The changes introduce an X-macro pattern for defining counters, expand the configuration options for each counter (mode, level, and reduction method), and update the generated code and data structures to support these enhancements. These updates will make it easier to add new counters, configure their behavior, and process their data at different aggregation levels.

**Counter definition and configuration overhaul:**

* Switched counter definitions in `Counter.h` to use an X-macro (`ARTS_COUNTER_LIST`), enabling easier maintenance and automatic generation of both enum values and name strings.
* Expanded the counter configuration parsing in `CMakeLists.txt` to support not only mode (OFF, ONCE, PERIODIC), but also aggregation level (THREAD, NODE, CLUSTER) and reduction method (SUM, MAX, MIN, MASTER), with sensible defaults if not specified.
* Updated the code generation to emit separate macros and arrays for each counter's mode, level, and reduction method, replacing the previous approach that only supported mode. [[1]](diffhunk://#diff-1f049bd98453a6c7105e785977ee8a0f578811319891ccf2117fa7a4c9c01f54L160-R212) [[2]](diffhunk://#diff-1f049bd98453a6c7105e785977ee8a0f578811319891ccf2117fa7a4c9c01f54L214-R300)

**Data structure and API changes:**

* Refactored counter-related data structures in `Counter.h` to align with the new configuration options, including new enums for mode, level, and reduction method, and clarified the storage and reduction strategy for captured values.
* Changed thread-local counter access in generated macros to use `artsThreadLocalCounters` instead of the previous `artsThreadInfo.artsCounters`, reflecting the new storage approach.

**Other improvements:**

* Cleaned up includes and removed obsolete code related to the previous enum-based counter definition.

These changes together provide a more powerful and maintainable foundation for performance counter introspection in the codebase.